### PR TITLE
Implement snapshots in clds_hash_table with tests

### DIFF
--- a/devdoc/clds_hash_table_requirements.md
+++ b/devdoc/clds_hash_table_requirements.md
@@ -82,6 +82,12 @@ MU_DEFINE_ENUM(CLDS_HASH_TABLE_DELETE_RESULT, CLDS_HASH_TABLE_DELETE_RESULT_VALU
 
 MU_DEFINE_ENUM(CLDS_HASH_TABLE_REMOVE_RESULT, CLDS_HASH_TABLE_REMOVE_RESULT_VALUES);
 
+#define CLDS_HASH_TABLE_SET_VALUE_RESULT_VALUES \
+    CLDS_HASH_TABLE_SET_VALUE_OK, \
+    CLDS_HASH_TABLE_SET_VALUE_ERROR
+
+MU_DEFINE_ENUM(CLDS_HASH_TABLE_SET_VALUE_RESULT, CLDS_HASH_TABLE_SET_VALUE_RESULT_VALUES);
+
 #define CLDS_HASH_TABLE_SNAPSHOT_RESULT_VALUES \
     CLDS_HASH_TABLE_SNAPSHOT_OK, \
     CLDS_HASH_TABLE_SNAPSHOT_ERROR
@@ -97,7 +103,7 @@ MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_REMOVE_RESULT, clds_hash_table_remove, CLDS_
 MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_SET_VALUE_RESULT, clds_hash_table_set_value, CLDS_HASH_TABLE_HANDLE, clds_hash_table, CLDS_HAZARD_POINTERS_THREAD_HANDLE, clds_hazard_pointers_thread, const void*, key, CLDS_HASH_TABLE_ITEM*, new_item, CLDS_HASH_TABLE_ITEM**, old_item, int64_t*, sequence_number);
 MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_ITEM*, clds_hash_table_find, CLDS_HASH_TABLE_HANDLE, clds_hash_table, CLDS_HAZARD_POINTERS_THREAD_HANDLE, clds_hazard_pointers_thread, void*, key);
 
-MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_SNAPSHOT_RESULT, clds_hash_table_snapshot, CLDS_HASH_TABLE_HANDLE, clds_hash_table, CLDS_HAZARD_POINTERS_THREAD_HANDLE, clds_hazard_pointers_thread, CLDS_HASH_TABLE_ITEM** items, uint64_t*, item_count);
+MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_SNAPSHOT_RESULT, clds_hash_table_snapshot, CLDS_HASH_TABLE_HANDLE, clds_hash_table, CLDS_HAZARD_POINTERS_THREAD_HANDLE, clds_hazard_pointers_thread, CLDS_HASH_TABLE_ITEM***, items, uint64_t*, item_count);
 
 // helper APIs for creating/destroying a hash table node
 MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_ITEM*, clds_hash_table_node_create, size_t, node_size, HASH_TABLE_ITEM_CLEANUP_CB, item_cleanup_callback, void*, item_cleanup_callback_context);
@@ -161,15 +167,15 @@ MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_INSERT_RESULT, clds_hash_table_insert, CLDS_
 
 **SRS_CLDS_HASH_TABLE_01_012: [** If `clds_hazard_pointers_thread` is NULL, `clds_hash_table_insert` shall fail and return `CLDS_HASH_TABLE_INSERT_ERROR`. **]**
 
-`clds_hash_table_insert` shall try the following until it acquires a write lock for the table:
+**SRS_CLDS_HASH_TABLE_42_032: [** `clds_hash_table_insert` shall try the following until it acquires a write lock for the table: **]**
 
- - `clds_hash_table_insert` shall increment the count of pending write operations.
+ - **SRS_CLDS_HASH_TABLE_42_033: [** `clds_hash_table_insert` shall increment the count of pending write operations. **]**
 
- - If the counter to lock the table for writes is non-zero then:
+ - **SRS_CLDS_HASH_TABLE_42_034: [** If the counter to lock the table for writes is non-zero then: **]**
 
-   - `clds_hash_table_insert` shall decrement the count of pending write operations.
+   - **SRS_CLDS_HASH_TABLE_42_035: [** `clds_hash_table_insert` shall decrement the count of pending write operations. **]**
 
-   - `clds_hash_table_insert` shall wait for the counter to lock the table for writes to reach 0 and repeat.
+   - **SRS_CLDS_HASH_TABLE_42_036: [** `clds_hash_table_insert` shall wait for the counter to lock the table for writes to reach 0 and repeat. **]**
 
 **SRS_CLDS_HASH_TABLE_01_038: [** `clds_hash_table_insert` shall hash the key by calling the `compute_hash` function passed to `clds_hash_table_create`. **]**
 
@@ -203,7 +209,7 @@ MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_INSERT_RESULT, clds_hash_table_insert, CLDS_
 
 **SRS_CLDS_HASH_TABLE_01_062: [** If the `sequence_number` argument is non-NULL, but no start sequence number was specified in `clds_hash_table_create`, `clds_hash_table_insert` shall fail and return `CLDS_HASH_TABLE_INSERT_ERROR`. **]**
 
-`clds_hash_table_insert` shall decrement the count of pending write operations.
+**SRS_CLDS_HASH_TABLE_42_063: [** `clds_hash_table_insert` shall decrement the count of pending write operations. **]**
 
 ### clds_hash_table_delete
 
@@ -223,15 +229,15 @@ MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_DELETE_RESULT, clds_hash_table_delete, CLDS_
 
 **SRS_CLDS_HASH_TABLE_01_016: [** If `key` is NULL, `clds_hash_table_delete` shall fail and return `CLDS_HASH_TABLE_DELETE_ERROR`. **]**
 
-`clds_hash_table_delete` shall try the following until it acquires a write lock for the table:
+**SRS_CLDS_HASH_TABLE_42_037: [** `clds_hash_table_delete` shall try the following until it acquires a write lock for the table: **]**
 
- - `clds_hash_table_delete` shall increment the count of pending write operations.
+ - **SRS_CLDS_HASH_TABLE_42_038: [** `clds_hash_table_delete` shall increment the count of pending write operations. **]**
 
- - If the counter to lock the table for writes is non-zero then:
+ - **SRS_CLDS_HASH_TABLE_42_039: [** If the counter to lock the table for writes is non-zero then: **]**
 
-   - `clds_hash_table_delete` shall decrement the count of pending write operations.
+   - **SRS_CLDS_HASH_TABLE_42_040: [** `clds_hash_table_delete` shall decrement the count of pending write operations. **]**
 
-   - `clds_hash_table_delete` shall wait for the counter to lock the table for writes to reach 0 and repeat.
+   - **SRS_CLDS_HASH_TABLE_42_041: [** `clds_hash_table_delete` shall wait for the counter to lock the table for writes to reach 0 and repeat. **]**
 
 **SRS_CLDS_HASH_TABLE_01_101: [** Otherwise, `key` shall be looked up in each of the arrays of buckets starting with the first. **]**
 
@@ -245,7 +251,7 @@ MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_DELETE_RESULT, clds_hash_table_delete, CLDS_
 
 **SRS_CLDS_HASH_TABLE_01_066: [** If the `sequence_number` argument is non-NULL, but no start sequence number was specified in `clds_hash_table_create`, `clds_hash_table_delete` shall fail and return `CLDS_HASH_TABLE_DELETE_ERROR`. **]**
 
-`clds_hash_table_insert` shall decrement the count of pending write operations.
+**SRS_CLDS_HASH_TABLE_42_042: [** `clds_hash_table_insert` shall decrement the count of pending write operations. **]**
 
 ### clds_hash_table_delete_key_value
 
@@ -267,15 +273,15 @@ MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_DELETE_RESULT, clds_hash_table_delete_key_va
 
 **SRS_CLDS_HASH_TABLE_42_006: [** If `value` is `NULL`, `clds_hash_table_delete_key_value` shall fail and return `CLDS_HASH_TABLE_DELETE_ERROR`. **]**
 
-`clds_hash_table_delete_key_value` shall try the following until it acquires a write lock for the table:
+**SRS_CLDS_HASH_TABLE_42_043: [** `clds_hash_table_delete_key_value` shall try the following until it acquires a write lock for the table: **]**
 
- - `clds_hash_table_delete_key_value` shall increment the count of pending write operations.
+ - **SRS_CLDS_HASH_TABLE_42_044: [** `clds_hash_table_delete_key_value` shall increment the count of pending write operations. **]**
 
- - If the counter to lock the table for writes is non-zero then:
+ - **SRS_CLDS_HASH_TABLE_42_045: [** If the counter to lock the table for writes is non-zero then: **]**
 
-   - `clds_hash_table_delete_key_value` shall decrement the count of pending write operations.
+   - **SRS_CLDS_HASH_TABLE_42_046: [** `clds_hash_table_delete_key_value` shall decrement the count of pending write operations. **]**
 
-   - `clds_hash_table_delete_key_value` shall wait for the counter to lock the table for writes to reach 0 and repeat.
+   - **SRS_CLDS_HASH_TABLE_42_047: [** `clds_hash_table_delete_key_value` shall wait for the counter to lock the table for writes to reach 0 and repeat. **]**
 
 **SRS_CLDS_HASH_TABLE_42_007: [** Otherwise, `key` shall be looked up in each of the arrays of buckets starting with the first. **]**
 
@@ -289,7 +295,7 @@ MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_DELETE_RESULT, clds_hash_table_delete_key_va
 
 **SRS_CLDS_HASH_TABLE_42_012: [** If the `sequence_number` argument is non-`NULL`, but no start sequence number was specified in `clds_hash_table_create`, `clds_hash_table_delete_key_value` shall fail and return `CLDS_HASH_TABLE_DELETE_ERROR`. **]**
 
-`clds_hash_table_delete_key_value` shall decrement the count of pending write operations.
+**SRS_CLDS_HASH_TABLE_42_048: [** `clds_hash_table_delete_key_value` shall decrement the count of pending write operations. **]**
 
 ### clds_hash_table_remove
 
@@ -311,15 +317,15 @@ MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_REMOVE_RESULT, clds_hash_table_remove, CLDS_
 
 **SRS_CLDS_HASH_TABLE_01_056: [** If `item` is NULL, `clds_hash_table_remove` shall fail and return `CLDS_HASH_TABLE_REMOVE_ERROR`. **]**
 
-`clds_hash_table_remove` shall try the following until it acquires a write lock for the table:
+**SRS_CLDS_HASH_TABLE_42_049: [** `clds_hash_table_remove` shall try the following until it acquires a write lock for the table: **]**
 
- - `clds_hash_table_remove` shall increment the count of pending write operations.
+ - **SRS_CLDS_HASH_TABLE_42_050: [** `clds_hash_table_remove` shall increment the count of pending write operations. **]**
 
- - If the counter to lock the table for writes is non-zero then:
+ - **SRS_CLDS_HASH_TABLE_42_051: [** If the counter to lock the table for writes is non-zero then: **]**
 
-   - `clds_hash_table_remove` shall decrement the count of pending write operations.
+   - **SRS_CLDS_HASH_TABLE_42_052: [** `clds_hash_table_remove` shall decrement the count of pending write operations. **]**
 
-   - `clds_hash_table_remove` shall wait for the counter to lock the table for writes to reach 0 and repeat.
+   - **SRS_CLDS_HASH_TABLE_42_053: [** `clds_hash_table_remove` shall wait for the counter to lock the table for writes to reach 0 and repeat. **]**
 
 **SRS_CLDS_HASH_TABLE_01_053: [** If the desired key is not found in the hash table (not found in any of the arrays of buckets), `clds_hash_table_remove` shall return `CLDS_HASH_TABLE_REMOVE_NOT_FOUND`. **]**
 
@@ -331,7 +337,7 @@ MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_REMOVE_RESULT, clds_hash_table_remove, CLDS_
 
 **SRS_CLDS_HASH_TABLE_01_070: [** If the `sequence_number` argument is non-NULL, but no start sequence number was specified in `clds_hash_table_create`, `clds_hash_table_remove` shall fail and return `CLDS_HASH_TABLE_REMOVE_ERROR`. **]**
 
-`clds_hash_table_remove` shall decrement the count of pending write operations.
+**SRS_CLDS_HASH_TABLE_42_054: [** `clds_hash_table_remove` shall decrement the count of pending write operations. **]**
 
 ### clds_hash_table_set_value
 
@@ -355,15 +361,15 @@ MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_SET_VALUE_RESULT, clds_hash_table_set_value,
 
 **SRS_CLDS_HASH_TABLE_01_084: [** If the `sequence_number` argument is non-NULL, but no start sequence number was specified in `clds_hash_table_create`, `clds_hash_table_set_value` shall fail and return `CLDS_HASH_TABLE_SET_VALUE_ERROR`. **]**
 
-`clds_hash_table_set_value` shall try the following until it acquires a write lock for the table:
+**SRS_CLDS_HASH_TABLE_42_055: [** `clds_hash_table_set_value` shall try the following until it acquires a write lock for the table: **]**
 
- - `clds_hash_table_set_value` shall increment the count of pending write operations.
+ - **SRS_CLDS_HASH_TABLE_42_056: [** `clds_hash_table_set_value` shall increment the count of pending write operations. **]**
 
- - If the counter to lock the table for writes is non-zero then:
+ - **SRS_CLDS_HASH_TABLE_42_057: [** If the counter to lock the table for writes is non-zero then: **]**
 
-   - `clds_hash_table_set_value` shall decrement the count of pending write operations.
+   - **SRS_CLDS_HASH_TABLE_42_058: [** `clds_hash_table_set_value` shall decrement the count of pending write operations. **]**
 
-   - `clds_hash_table_set_value` shall wait for the counter to lock the table for writes to reach 0 and repeat.
+   - **SRS_CLDS_HASH_TABLE_42_059: [** `clds_hash_table_set_value` shall wait for the counter to lock the table for writes to reach 0 and repeat. **]**
 
 **S_R_S_CLDS_HASH_TABLE_01_085: [** `clds_hash_table_set_value` shall call `clds_sorted_list_set_value` on the first (topmost) bucket array while passing `key`, `new_item` and `old_item` as arguments.. **]**
 
@@ -373,7 +379,7 @@ MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_SET_VALUE_RESULT, clds_hash_table_set_value,
 
 **S_R_S_CLDS_HASH_TABLE_01_095: [** If any error occurs, `clds_hash_table_set_value` shall return `CLDS_HASH_TABLE_SET_VALUE_ERROR`. **]**
 
-`clds_hash_table_set_value` shall decrement the count of pending write operations.
+**SRS_CLDS_HASH_TABLE_42_060: [** `clds_hash_table_set_value` shall decrement the count of pending write operations. **]**
 
 ### clds_hash_table_find
 
@@ -412,45 +418,51 @@ static void on_sorted_list_skipped_seq_no(void* context, int64_t skipped_sequenc
 ### clds_hash_table_snapshot
 
 ```c
-MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_SNAPSHOT_RESULT, clds_hash_table_snapshot, CLDS_HASH_TABLE_HANDLE, clds_hash_table, CLDS_HAZARD_POINTERS_THREAD_HANDLE, clds_hazard_pointers_thread, CLDS_HASH_TABLE_ITEM** items, uint64_t*, item_count);
+MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_SNAPSHOT_RESULT, clds_hash_table_snapshot, CLDS_HASH_TABLE_HANDLE, clds_hash_table, CLDS_HAZARD_POINTERS_THREAD_HANDLE, clds_hazard_pointers_thread, CLDS_HASH_TABLE_ITEM***, items, uint64_t*, item_count);
 ```
 
 `clds_hash_table_snapshot` locks the table for writes and collects all of the items in the table into an array then unlocks the table. During this call, `clds_hash_table_find` will continue to work, but other APIs will block.
 
-If `clds_hash_table` is `NULL` then `clds_hash_table_snapshot` shall fail and return `CLDS_HASH_TABLE_SNAPSHOT_ERROR`.
+**SRS_CLDS_HASH_TABLE_42_013: [** If `clds_hash_table` is `NULL` then `clds_hash_table_snapshot` shall fail and return `CLDS_HASH_TABLE_SNAPSHOT_ERROR`. **]**
 
-If `clds_hazard_pointers_thread` is `NULL` then `clds_hash_table_snapshot` shall fail and return `CLDS_HASH_TABLE_SNAPSHOT_ERROR`.
+**SRS_CLDS_HASH_TABLE_42_014: [** If `clds_hazard_pointers_thread` is `NULL` then `clds_hash_table_snapshot` shall fail and return `CLDS_HASH_TABLE_SNAPSHOT_ERROR`. **]**
 
-If `items` is `NULL` then `clds_hash_table_snapshot` shall fail and return `CLDS_HASH_TABLE_SNAPSHOT_ERROR`.
+**SRS_CLDS_HASH_TABLE_42_015: [** If `items` is `NULL` then `clds_hash_table_snapshot` shall fail and return `CLDS_HASH_TABLE_SNAPSHOT_ERROR`. **]**
 
-If `item_count` is `NULL` then `clds_hash_table_snapshot` shall fail and return `CLDS_HASH_TABLE_SNAPSHOT_ERROR`.
+**SRS_CLDS_HASH_TABLE_42_016: [** If `item_count` is `NULL` then `clds_hash_table_snapshot` shall fail and return `CLDS_HASH_TABLE_SNAPSHOT_ERROR`. **]**
 
-`clds_hash_table_snapshot` shall increment a counter to lock the table for writes.
+**SRS_CLDS_HASH_TABLE_42_017: [** `clds_hash_table_snapshot` shall increment a counter to lock the table for writes. **]**
 
-`clds_hash_table_snapshot` shall wait for the ongoing write operations to complete.
+**SRS_CLDS_HASH_TABLE_42_018: [** `clds_hash_table_snapshot` shall wait for the ongoing write operations to complete. **]**
 
-For each bucket in the array:
+**SRS_CLDS_HASH_TABLE_42_019: [** For each bucket in the array: **]**
 
- - `clds_hash_table_snapshot` shall call `clds_sorted_list_lock_writes`.
+ - **SRS_CLDS_HASH_TABLE_42_020: [** `clds_hash_table_snapshot` shall call `clds_sorted_list_lock_writes`. **]**
 
- - `clds_hash_table_snapshot` shall call `clds_sorted_list_get_count` and add to the running total.
+ - **SRS_CLDS_HASH_TABLE_42_021: [** `clds_hash_table_snapshot` shall call `clds_sorted_list_get_count` and add to the running total. **]**
 
- - If the addition of the list count causes overflow then `clds_hash_table_snapshot` shall fail and return `CLDS_HASH_TABLE_SNAPSHOT_ERROR`.
+ - **SRS_CLDS_HASH_TABLE_42_022: [** If the addition of the list count causes overflow then `clds_hash_table_snapshot` shall fail and return `CLDS_HASH_TABLE_SNAPSHOT_ERROR`. **]**
 
-`clds_hash_table_snapshot` shall allocate an array of `CLDS_HASH_TABLE_ITEM*`
+**SRS_CLDS_HASH_TABLE_42_062: [** If the number of items multiplied by the size of `CLDS_HASH_TABLE_ITEM` exceeds `SIZE_MAX` then `clds_hash_table_snapshot` shall fail and return `CLDS_HASH_TABLE_SNAPSHOT_ERROR`. **]**
 
-For each bucket in the array:
+**SRS_CLDS_HASH_TABLE_42_064: [** If there are no items then `clds_hash_table_snapshot` shall set `items` to `NULL` and `item_count` to `0` and return `CLDS_HASH_TABLE_SNAPSHOT_OK`. **]**
 
- - `clds_hash_table_snapshot` shall call `clds_sorted_list_get_count`.
+**SRS_CLDS_HASH_TABLE_42_023: [** `clds_hash_table_snapshot` shall allocate an array of `CLDS_HASH_TABLE_ITEM*` **]**
 
- - `clds_hash_table_snapshot` shall call `clds_sorted_list_get_all` with the next portion of the allocated array.
+**SRS_CLDS_HASH_TABLE_42_024: [** For each bucket in the array: **]**
 
- - `clds_hash_table_snapshot` shall call `clds_sorted_list_unlock_writes`.
+ - **SRS_CLDS_HASH_TABLE_42_025: [** `clds_hash_table_snapshot` shall call `clds_sorted_list_get_count`. **]**
 
-`clds_hash_table_snapshot` shall store the allocated array of items in `items`.
+ - **SRS_CLDS_HASH_TABLE_42_026: [** `clds_hash_table_snapshot` shall call `clds_sorted_list_get_all` with the next portion of the allocated array. **]**
 
-`clds_hash_table_snapshot` shall store the count of items in `item_count`.
+ - **SRS_CLDS_HASH_TABLE_42_027: [** `clds_hash_table_snapshot` shall call `clds_sorted_list_unlock_writes`. **]**
 
-`clds_hash_table_snapshot` shall decrement the counter to unlock the table for writes.
+**SRS_CLDS_HASH_TABLE_42_028: [** `clds_hash_table_snapshot` shall store the allocated array of items in `items`. **]**
 
-`clds_hash_table_snapshot` shall succeed and return `CLDS_HASH_TABLE_SNAPSHOT_OK`.
+**SRS_CLDS_HASH_TABLE_42_029: [** `clds_hash_table_snapshot` shall store the count of items in `item_count`. **]**
+
+**SRS_CLDS_HASH_TABLE_42_030: [** `clds_hash_table_snapshot` shall decrement the counter to unlock the table for writes. **]**
+
+**SRS_CLDS_HASH_TABLE_42_061: [** If there are any other failures then `clds_hash_table_snapshot` shall fail and return `CLDS_HASH_TABLE_SNAPSHOT_ERROR`. **]**
+
+**SRS_CLDS_HASH_TABLE_42_031: [** `clds_hash_table_snapshot` shall succeed and return `CLDS_HASH_TABLE_SNAPSHOT_OK`. **]**

--- a/inc/clds/clds_atomics.h
+++ b/inc/clds/clds_atomics.h
@@ -3,6 +3,11 @@
 #ifndef CLDS_ATOMICS_H
 #define CLDS_ATOMICS_H
 
+#ifdef __cplusplus
+#else
+#include <stdbool.h>
+#endif
+
 #include "umock_c/umock_c_prod.h"
 #include "azure_macro_utils/macro_utils.h"
 
@@ -11,8 +16,6 @@
 
 #ifdef __cplusplus
 extern "C" {
-#else
-#include <stdbool.h>
 #endif
 
 #ifdef __STDC_VERSION__

--- a/inc/clds/clds_hash_table.h
+++ b/inc/clds/clds_hash_table.h
@@ -3,16 +3,19 @@
 #ifndef CLDS_HASH_TABLE_H
 #define CLDS_HASH_TABLE_H
 
+#ifdef __cplusplus
+#include <cstdint>
+#else
+#include <stdint.h>
+#endif
+
 #include "windows.h"
 #include "umock_c/umock_c_prod.h"
 #include "clds_hazard_pointers.h"
 #include "clds_sorted_list.h"
 
 #ifdef __cplusplus
-#include <cstdint>
 extern "C" {
-#else
-#include <stdint.h>
 #endif
 
 struct CLDS_HASH_TABLE_ITEM_TAG;
@@ -82,6 +85,12 @@ MU_DEFINE_ENUM(CLDS_HASH_TABLE_REMOVE_RESULT, CLDS_HASH_TABLE_REMOVE_RESULT_VALU
 
 MU_DEFINE_ENUM(CLDS_HASH_TABLE_SET_VALUE_RESULT, CLDS_HASH_TABLE_SET_VALUE_RESULT_VALUES);
 
+#define CLDS_HASH_TABLE_SNAPSHOT_RESULT_VALUES \
+    CLDS_HASH_TABLE_SNAPSHOT_OK, \
+    CLDS_HASH_TABLE_SNAPSHOT_ERROR
+
+MU_DEFINE_ENUM(CLDS_HASH_TABLE_SNAPSHOT_RESULT, CLDS_HASH_TABLE_SNAPSHOT_RESULT_VALUES);
+
 MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_HANDLE, clds_hash_table_create, COMPUTE_HASH_FUNC, compute_hash, KEY_COMPARE_FUNC, key_compare_func, size_t, initial_bucket_size, CLDS_HAZARD_POINTERS_HANDLE, clds_hazard_pointers, volatile int64_t*, start_sequence_number, HASH_TABLE_SKIPPED_SEQ_NO_CB, skipped_seq_no_cb, void*, skipped_seq_no_cb_context);
 MOCKABLE_FUNCTION(, void, clds_hash_table_destroy, CLDS_HASH_TABLE_HANDLE, clds_hash_table);
 MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_INSERT_RESULT, clds_hash_table_insert, CLDS_HASH_TABLE_HANDLE, clds_hash_table, CLDS_HAZARD_POINTERS_THREAD_HANDLE, clds_hazard_pointers_thread, void*, key, CLDS_HASH_TABLE_ITEM*, value, int64_t*, sequence_number);
@@ -90,6 +99,8 @@ MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_DELETE_RESULT, clds_hash_table_delete_key_va
 MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_REMOVE_RESULT, clds_hash_table_remove, CLDS_HASH_TABLE_HANDLE, clds_hash_table, CLDS_HAZARD_POINTERS_THREAD_HANDLE, clds_hazard_pointers_thread, void*, key, CLDS_HASH_TABLE_ITEM**, item, int64_t*, sequence_number);
 MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_SET_VALUE_RESULT, clds_hash_table_set_value, CLDS_HASH_TABLE_HANDLE, clds_hash_table, CLDS_HAZARD_POINTERS_THREAD_HANDLE, clds_hazard_pointers_thread, const void*, key, CLDS_HASH_TABLE_ITEM*, new_item, CLDS_HASH_TABLE_ITEM**, old_item, int64_t*, sequence_number);
 MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_ITEM*, clds_hash_table_find, CLDS_HASH_TABLE_HANDLE, clds_hash_table, CLDS_HAZARD_POINTERS_THREAD_HANDLE, clds_hazard_pointers_thread, void*, key);
+
+MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_SNAPSHOT_RESULT, clds_hash_table_snapshot, CLDS_HASH_TABLE_HANDLE, clds_hash_table, CLDS_HAZARD_POINTERS_THREAD_HANDLE, clds_hazard_pointers_thread, CLDS_HASH_TABLE_ITEM***, items, uint64_t*, item_count);
 
 // helper APIs for creating/destroying a hash table node
 MOCKABLE_FUNCTION(, CLDS_HASH_TABLE_ITEM*, clds_hash_table_node_create, size_t, node_size, HASH_TABLE_ITEM_CLEANUP_CB, item_cleanup_callback, void*, item_cleanup_callback_context);

--- a/inc/clds/clds_hazard_pointers.h
+++ b/inc/clds/clds_hazard_pointers.h
@@ -3,15 +3,17 @@
 #ifndef CLDS_HAZARD_POINTERS_H
 #define CLDS_HAZARD_POINTERS_H
 
-#include "umock_c/umock_c_prod.h"
-
 #ifdef __cplusplus
 #include <cstdint>
 #include <cstddef>
-extern "C" {
 #else
 #include <stdint.h>
 #include <stddef.h>
+#endif
+
+#include "umock_c/umock_c_prod.h"
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 typedef struct CLDS_HAZARD_POINTERS_TAG* CLDS_HAZARD_POINTERS_HANDLE;

--- a/inc/clds/clds_st_hash_set.h
+++ b/inc/clds/clds_st_hash_set.h
@@ -5,13 +5,16 @@
 
 #ifdef __cplusplus
 #include <cstdint>
-extern "C" {
 #else
 #include <stdint.h>
 #endif
 
 #include "azure_macro_utils/macro_utils.h"
 #include "umock_c/umock_c_prod.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct CLDS_ST_HASH_SET_TAG* CLDS_ST_HASH_SET_HANDLE;
 typedef uint64_t (*CLDS_ST_HASH_SET_COMPUTE_HASH_FUNC)(void* key);

--- a/inc/clds/lock_free_set.h
+++ b/inc/clds/lock_free_set.h
@@ -3,12 +3,12 @@
 #ifndef LOCK_FREE_SET_H
 #define LOCK_FREE_SET_H
 
+#include "umock_c/umock_c_prod.h"
+#include "clds/clds_atomics.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "umock_c/umock_c_prod.h"
-#include "clds/clds_atomics.h"
 
 typedef struct LOCK_FREE_SET_TAG* LOCK_FREE_SET_HANDLE;
 

--- a/src/clds_hash_table.c
+++ b/src/clds_hash_table.c
@@ -129,7 +129,7 @@ static void on_sorted_list_skipped_seq_no(void* context, int64_t skipped_sequenc
 static BUCKET_ARRAY* get_first_bucket_array(CLDS_HASH_TABLE* clds_hash_table)
 {
     // always insert in the first bucket array
-    BUCKET_ARRAY* first_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&clds_hash_table->first_hash_table, NULL, NULL);
+    BUCKET_ARRAY* first_bucket_array = InterlockedCompareExchangePointer((volatile PVOID*)&clds_hash_table->first_hash_table, NULL, NULL);
     LONG bucket_count = InterlockedAdd(&first_bucket_array->bucket_count, 0);
     while (InterlockedAdd(&first_bucket_array->item_count, 0) >= bucket_count)
     {
@@ -163,7 +163,7 @@ static BUCKET_ARRAY* get_first_bucket_array(CLDS_HASH_TABLE* clds_hash_table)
                 // first bucket array changed, drop ours and use the one that was inserted
                 free(new_bucket_array);
 
-                first_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&clds_hash_table->first_hash_table, NULL, NULL);
+                first_bucket_array = InterlockedCompareExchangePointer((volatile PVOID*)&clds_hash_table->first_hash_table, NULL, NULL);
                 bucket_count = InterlockedAdd(&first_bucket_array->bucket_count, 0);
             }
         }
@@ -277,10 +277,10 @@ void clds_hash_table_destroy(CLDS_HASH_TABLE_HANDLE clds_hash_table)
     {
         LONG i;
 
-        BUCKET_ARRAY* bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&clds_hash_table->first_hash_table, NULL, NULL);
+        BUCKET_ARRAY* bucket_array = InterlockedCompareExchangePointer((volatile PVOID*)&clds_hash_table->first_hash_table, NULL, NULL);
         while (bucket_array != NULL)
         {
-            BUCKET_ARRAY* next_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&bucket_array->next_bucket, NULL, NULL);
+            BUCKET_ARRAY* next_bucket_array = InterlockedCompareExchangePointer((volatile PVOID*)&bucket_array->next_bucket, NULL, NULL);
 
             /* Codes_SRS_CLDS_HASH_TABLE_01_006: [ clds_hash_table_destroy shall free all resources associated with the hash table instance. ]*/
             for (i = 0; i < bucket_array->bucket_count; i++)
@@ -354,7 +354,7 @@ CLDS_HASH_TABLE_INSERT_RESULT clds_hash_table_insert(CLDS_HASH_TABLE_HANDLE clds
 
         // check if the key exists in the lover level bucket arrays
         BUCKET_ARRAY* find_bucket_array = current_bucket_array;
-        BUCKET_ARRAY* next_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&find_bucket_array->next_bucket, NULL, NULL);
+        BUCKET_ARRAY* next_bucket_array = InterlockedCompareExchangePointer((volatile PVOID*)&find_bucket_array->next_bucket, NULL, NULL);
 
         if (next_bucket_array != NULL)
         {
@@ -371,7 +371,7 @@ CLDS_HASH_TABLE_INSERT_RESULT clds_hash_table_insert(CLDS_HASH_TABLE_HANDLE clds
         find_bucket_array = next_bucket_array;
         while (find_bucket_array != NULL)
         {
-            next_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&find_bucket_array->next_bucket, NULL, NULL);
+            next_bucket_array = InterlockedCompareExchangePointer((volatile PVOID*)&find_bucket_array->next_bucket, NULL, NULL);
 
             bucket_index = hash % InterlockedAdd(&find_bucket_array->bucket_count, 0);
             bucket_list = InterlockedCompareExchangePointer(&find_bucket_array->hash_table[bucket_index], NULL, NULL);
@@ -544,10 +544,10 @@ CLDS_HASH_TABLE_DELETE_RESULT clds_hash_table_delete(CLDS_HASH_TABLE_HANDLE clds
 
         // always delete starting with the first bucket array
         /* Codes_SRS_CLDS_HASH_TABLE_01_101: [ Otherwise, `key` shall be looked up in each of the arrays of buckets starting with the first. ]*/
-        current_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&clds_hash_table->first_hash_table, NULL, NULL);
+        current_bucket_array = InterlockedCompareExchangePointer((volatile PVOID*)&clds_hash_table->first_hash_table, NULL, NULL);
         while (current_bucket_array != NULL)
         {
-            BUCKET_ARRAY* next_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&current_bucket_array->next_bucket, NULL, NULL);
+            BUCKET_ARRAY* next_bucket_array = InterlockedCompareExchangePointer((volatile PVOID*)&current_bucket_array->next_bucket, NULL, NULL);
 
             if (InterlockedAdd(&current_bucket_array->item_count, 0) != 0)
             {
@@ -640,10 +640,10 @@ CLDS_HASH_TABLE_DELETE_RESULT clds_hash_table_delete_key_value(CLDS_HASH_TABLE_H
 
         // always insert in the first bucket array
         /*Codes_SRS_CLDS_HASH_TABLE_42_007: [ Otherwise, key shall be looked up in each of the arrays of buckets starting with the first. ]*/
-        current_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&clds_hash_table->first_hash_table, NULL, NULL);
+        current_bucket_array = InterlockedCompareExchangePointer((volatile PVOID*)&clds_hash_table->first_hash_table, NULL, NULL);
         while (current_bucket_array != NULL)
         {
-            BUCKET_ARRAY* next_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&current_bucket_array->next_bucket, NULL, NULL);
+            BUCKET_ARRAY* next_bucket_array = InterlockedCompareExchangePointer((volatile PVOID*)&current_bucket_array->next_bucket, NULL, NULL);
 
             if (InterlockedAdd(&current_bucket_array->item_count, 0) != 0)
             {
@@ -736,10 +736,10 @@ CLDS_HASH_TABLE_REMOVE_RESULT clds_hash_table_remove(CLDS_HASH_TABLE_HANDLE clds
         result = CLDS_HASH_TABLE_REMOVE_NOT_FOUND;
 
         // always insert in the first bucket array
-        current_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&clds_hash_table->first_hash_table, NULL, NULL);
+        current_bucket_array = InterlockedCompareExchangePointer((volatile PVOID*)&clds_hash_table->first_hash_table, NULL, NULL);
         while (current_bucket_array != NULL)
         {
-            BUCKET_ARRAY* next_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&current_bucket_array->next_bucket, NULL, NULL);
+            BUCKET_ARRAY* next_bucket_array = InterlockedCompareExchangePointer((volatile PVOID*)&current_bucket_array->next_bucket, NULL, NULL);
 
             if (InterlockedAdd(&current_bucket_array->item_count, 0) != 0)
             {
@@ -830,7 +830,7 @@ CLDS_HASH_TABLE_SET_VALUE_RESULT clds_hash_table_set_value(CLDS_HASH_TABLE_HANDL
         // increment pending inserts count
         (void)InterlockedIncrement(&first_bucket_array->pending_insert_count);
 
-        BUCKET_ARRAY* next_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&first_bucket_array->next_bucket, NULL, NULL);
+        BUCKET_ARRAY* next_bucket_array = InterlockedCompareExchangePointer((volatile PVOID*)&first_bucket_array->next_bucket, NULL, NULL);
         if (next_bucket_array != NULL)
         {
             // wait for all outstanding inserts in the lower levels to complete
@@ -912,12 +912,12 @@ CLDS_HASH_TABLE_SET_VALUE_RESULT clds_hash_table_set_value(CLDS_HASH_TABLE_HANDL
                 }
 
                 // now remove any leftovers in the lower layers
-                current_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&first_bucket_array->next_bucket, NULL, NULL);
+                current_bucket_array = InterlockedCompareExchangePointer((volatile PVOID*)&first_bucket_array->next_bucket, NULL, NULL);
                 while (current_bucket_array != NULL)
                 {
                     int64_t remove_seq_no;
                     CLDS_SORTED_LIST_ITEM* removed_old_item;
-                    next_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&current_bucket_array->next_bucket, NULL, NULL);
+                    next_bucket_array = InterlockedCompareExchangePointer((volatile PVOID*)&current_bucket_array->next_bucket, NULL, NULL);
                     bucket_index = hash % InterlockedAdd(&current_bucket_array->bucket_count, 0);
                     bucket_list = InterlockedCompareExchangePointer(&current_bucket_array->hash_table[bucket_index], NULL, NULL);
                     if (bucket_list != NULL)
@@ -982,10 +982,10 @@ CLDS_HASH_TABLE_ITEM* clds_hash_table_find(CLDS_HASH_TABLE_HANDLE clds_hash_tabl
         uint64_t hash = clds_hash_table->compute_hash(key);
 
         /* Codes_SRS_CLDS_HASH_TABLE_01_041: [ clds_hash_table_find shall look up the key in the biggest array of buckets. ]*/
-        BUCKET_ARRAY* current_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&clds_hash_table->first_hash_table, NULL, NULL);
+        BUCKET_ARRAY* current_bucket_array = InterlockedCompareExchangePointer((volatile PVOID*)&clds_hash_table->first_hash_table, NULL, NULL);
         while (current_bucket_array != NULL)
         {
-            BUCKET_ARRAY* next_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&current_bucket_array->next_bucket, NULL, NULL);
+            BUCKET_ARRAY* next_bucket_array = InterlockedCompareExchangePointer((volatile PVOID*)&current_bucket_array->next_bucket, NULL, NULL);
 
             if (InterlockedAdd(&current_bucket_array->item_count, 0) != 0)
             {
@@ -1044,7 +1044,7 @@ CLDS_HASH_TABLE_SNAPSHOT_RESULT clds_hash_table_snapshot(CLDS_HASH_TABLE_HANDLE 
         (item_count == NULL)
         )
     {
-        LogError("Invalid arguments: CLDS_HASH_TABLE_HANDLE clds_hash_table=%p, CLDS_HAZARD_POINTERS_THREAD_HANDLE clds_hazard_pointers_thread=%p, CLDS_HASH_TABLE_ITEM** items=%p, uint64_t* item_count=%p",
+        LogError("Invalid arguments: CLDS_HASH_TABLE_HANDLE clds_hash_table=%p, CLDS_HAZARD_POINTERS_THREAD_HANDLE clds_hazard_pointers_thread=%p, CLDS_HASH_TABLE_ITEM*** items=%p, uint64_t* item_count=%p",
             clds_hash_table, clds_hazard_pointers_thread, items, item_count);
         result = CLDS_HASH_TABLE_SNAPSHOT_ERROR;
     }
@@ -1057,10 +1057,10 @@ CLDS_HASH_TABLE_SNAPSHOT_RESULT clds_hash_table_snapshot(CLDS_HASH_TABLE_HANDLE 
         bool need_to_unlock_all = false;
 
         /* Codes_SRS_CLDS_HASH_TABLE_42_019: [ For each bucket in the array: ]*/
-        BUCKET_ARRAY* current_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&clds_hash_table->first_hash_table, NULL, NULL);
+        BUCKET_ARRAY* current_bucket_array = InterlockedCompareExchangePointer((volatile PVOID*)&clds_hash_table->first_hash_table, NULL, NULL);
         while (current_bucket_array != NULL)
         {
-            BUCKET_ARRAY* next_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&current_bucket_array->next_bucket, NULL, NULL);
+            BUCKET_ARRAY* next_bucket_array = InterlockedCompareExchangePointer((volatile PVOID*)&current_bucket_array->next_bucket, NULL, NULL);
 
             if (InterlockedAdd(&current_bucket_array->item_count, 0) != 0)
             {
@@ -1153,10 +1153,10 @@ CLDS_HASH_TABLE_SNAPSHOT_RESULT clds_hash_table_snapshot(CLDS_HASH_TABLE_HANDLE 
                     uint64_t result_index = 0;
 
                     /* Codes_SRS_CLDS_HASH_TABLE_42_024: [ For each bucket in the array: ]*/
-                    current_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&clds_hash_table->first_hash_table, NULL, NULL);
+                    current_bucket_array = InterlockedCompareExchangePointer((volatile PVOID*)&clds_hash_table->first_hash_table, NULL, NULL);
                     while (current_bucket_array != NULL)
                     {
-                        BUCKET_ARRAY* next_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&current_bucket_array->next_bucket, NULL, NULL);
+                        BUCKET_ARRAY* next_bucket_array = InterlockedCompareExchangePointer((volatile PVOID*)&current_bucket_array->next_bucket, NULL, NULL);
 
                         if (InterlockedAdd(&current_bucket_array->item_count, 0) != 0)
                         {
@@ -1243,10 +1243,10 @@ CLDS_HASH_TABLE_SNAPSHOT_RESULT clds_hash_table_snapshot(CLDS_HASH_TABLE_HANDLE 
             // Unlock all the lists that have been locked so far
             // If we only looked at part of the table, the old "current_bucket_array" is already in a cleaned up state
             // Otherwise it is NULL and we will unlock everything
-            BUCKET_ARRAY* bucket_array_to_clean = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&clds_hash_table->first_hash_table, NULL, NULL);
+            BUCKET_ARRAY* bucket_array_to_clean = InterlockedCompareExchangePointer((volatile PVOID*)&clds_hash_table->first_hash_table, NULL, NULL);
             while (bucket_array_to_clean != current_bucket_array)
             {
-                BUCKET_ARRAY* next_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&bucket_array_to_clean->next_bucket, NULL, NULL);
+                BUCKET_ARRAY* next_bucket_array = InterlockedCompareExchangePointer((volatile PVOID*)&bucket_array_to_clean->next_bucket, NULL, NULL);
 
                 if (InterlockedAdd(&bucket_array_to_clean->item_count, 0) != 0)
                 {

--- a/src/clds_hash_table.c
+++ b/src/clds_hash_table.c
@@ -1125,7 +1125,7 @@ CLDS_HASH_TABLE_SNAPSHOT_RESULT clds_hash_table_snapshot(CLDS_HASH_TABLE_HANDLE 
         else if (temp_item_count > SIZE_MAX / sizeof(CLDS_SORTED_LIST_ITEM*))
         {
             /* Codes_SRS_CLDS_HASH_TABLE_42_062: [ If the number of items multiplied by the size of CLDS_HASH_TABLE_ITEM exceeds SIZE_MAX then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
-            LogError("Unable to allocate array of %zu items, requires more than %zu bytes", temp_item_count, SIZE_MAX);
+            LogError("Unable to allocate array of %" PRIu64 " items, requires more than %zu bytes", temp_item_count, SIZE_MAX);
             result = CLDS_HASH_TABLE_SNAPSHOT_ERROR;
         }
         else
@@ -1140,12 +1140,12 @@ CLDS_HASH_TABLE_SNAPSHOT_RESULT clds_hash_table_snapshot(CLDS_HASH_TABLE_HANDLE 
             else
             {
                 /* Codes_SRS_CLDS_HASH_TABLE_42_023: [ clds_hash_table_snapshot shall allocate an array of CLDS_HASH_TABLE_ITEM* ]*/
-                CLDS_SORTED_LIST_ITEM** items_to_return = malloc(sizeof(CLDS_SORTED_LIST_ITEM*) * temp_item_count);
+                CLDS_SORTED_LIST_ITEM** items_to_return = malloc(sizeof(CLDS_SORTED_LIST_ITEM*) * (size_t)temp_item_count);
 
                 if (items_to_return == NULL)
                 {
                     /* Codes_SRS_CLDS_HASH_TABLE_42_061: [ If there are any other failures then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
-                    LogError("malloc(%zu) failed for the items to return", sizeof(CLDS_SORTED_LIST_ITEM*) * temp_item_count);
+                    LogError("malloc(%zu) failed for the items to return", sizeof(CLDS_SORTED_LIST_ITEM*) * (size_t)temp_item_count);
                     result = CLDS_HASH_TABLE_SNAPSHOT_ERROR;
                 }
                 else

--- a/src/clds_hash_table.c
+++ b/src/clds_hash_table.c
@@ -35,6 +35,10 @@ typedef struct CLDS_HASH_TABLE_TAG
     volatile LONG64* sequence_number;
     HASH_TABLE_SKIPPED_SEQ_NO_CB skipped_seq_no_cb;
     void* skipped_seq_no_cb_context;
+
+    // Support for locking the list for writes
+    volatile LONG locked_for_write;
+    volatile LONG pending_write_operations;
 } CLDS_HASH_TABLE;
 
 typedef struct FIND_BY_KEY_VALUE_CONTEXT_TAG
@@ -43,6 +47,55 @@ typedef struct FIND_BY_KEY_VALUE_CONTEXT_TAG
     void* value;
     KEY_COMPARE_FUNC key_compare_func;
 } FIND_BY_KEY_VALUE_CONTEXT;
+
+static void check_lock_and_begin_write_operation(CLDS_HASH_TABLE_HANDLE clds_hash_table)
+{
+    ULONG locked_for_write;
+    do
+    {
+        (void)InterlockedIncrement(&clds_hash_table->pending_write_operations);
+        locked_for_write = InterlockedAdd(&clds_hash_table->locked_for_write, 0);
+        if (locked_for_write != 0)
+        {
+            (void)InterlockedDecrement(&clds_hash_table->pending_write_operations);
+            WakeByAddressAll((void*)&clds_hash_table->pending_write_operations);
+
+            // Wait for unlock
+            (void)WaitOnAddress(&clds_hash_table->locked_for_write, &locked_for_write, sizeof(locked_for_write), INFINITE);
+        }
+    } while (locked_for_write != 0);
+}
+
+static void end_write_operation(CLDS_HASH_TABLE_HANDLE clds_hash_table)
+{
+    (void)InterlockedDecrement(&clds_hash_table->pending_write_operations);
+    WakeByAddressAll((void*)&clds_hash_table->pending_write_operations);
+}
+
+static void internal_lock_writes(CLDS_HASH_TABLE_HANDLE clds_hash_table)
+{
+    /*Codes_SRS_CLDS_HASH_TABLE_42_017: [ clds_hash_table_snapshot shall increment a counter to lock the table for writes. ]*/
+    (void)InterlockedIncrement(&clds_hash_table->locked_for_write);
+
+    /*Codes_SRS_CLDS_HASH_TABLE_42_018: [ clds_hash_table_snapshot shall wait for the ongoing write operations to complete. ]*/
+    ULONG pending_writes;
+    do
+    {
+        pending_writes = InterlockedAdd(&clds_hash_table->pending_write_operations, 0);
+        if (pending_writes != 0)
+        {
+            // Wait for writes
+            (void)WaitOnAddress(&clds_hash_table->pending_write_operations, &pending_writes, sizeof(pending_writes), INFINITE);
+        }
+    } while (pending_writes != 0);
+}
+
+static void internal_unlock_writes(CLDS_HASH_TABLE_HANDLE clds_hash_table)
+{
+    /*Codes_SRS_CLDS_HASH_TABLE_42_030: [ clds_hash_table_snapshot shall decrement the counter to unlock the table for writes. ]*/
+    (void)InterlockedDecrement(&clds_hash_table->locked_for_write);
+    WakeByAddressAll((void*)&clds_hash_table->locked_for_write);
+}
 
 static void* get_item_key_cb(void* context, CLDS_SORTED_LIST_ITEM* item)
 {
@@ -172,6 +225,9 @@ CLDS_HASH_TABLE_HANDLE clds_hash_table_create(COMPUTE_HASH_FUNC compute_hash, KE
                 clds_hash_table->skipped_seq_no_cb = skipped_seq_no_cb;
                 clds_hash_table->skipped_seq_no_cb_context = skipped_seq_no_cb_context;
 
+                (void)InterlockedExchange(&clds_hash_table->pending_write_operations, 0);
+                (void)InterlockedExchange(&clds_hash_table->locked_for_write, 0);
+
                 /* Codes_SRS_CLDS_HASH_TABLE_01_057: [ start_sequence_number shall be used as the sequence number variable that shall be incremented at every operation that is done on the hash table. ]*/
                 clds_hash_table->sequence_number = start_sequence_number;
 
@@ -268,18 +324,25 @@ CLDS_HASH_TABLE_INSERT_RESULT clds_hash_table_insert(CLDS_HASH_TABLE_HANDLE clds
     }
     else
     {
+        /* Codes_SRS_CLDS_HASH_TABLE_42_032: [ clds_hash_table_insert shall try the following until it acquires a write lock for the table: ]*/
+        /* Codes_SRS_CLDS_HASH_TABLE_42_033: [ clds_hash_table_insert shall increment the count of pending write operations. ]*/
+        /* Codes_SRS_CLDS_HASH_TABLE_42_034: [ If the counter to lock the table for writes is non-zero then: ]*/
+        /* Codes_SRS_CLDS_HASH_TABLE_42_035: [ clds_hash_table_insert shall decrement the count of pending write operations. ]*/
+        /* Codes_SRS_CLDS_HASH_TABLE_42_036: [ clds_hash_table_insert shall wait for the counter to lock the table for writes to reach 0 and repeat. ]*/
+        check_lock_and_begin_write_operation(clds_hash_table);
+
         bool restart_needed;
         CLDS_SORTED_LIST_HANDLE bucket_list = NULL;
         HASH_TABLE_ITEM* hash_table_item = CLDS_SORTED_LIST_GET_VALUE(HASH_TABLE_ITEM, value);
         uint64_t hash;
         BUCKET_ARRAY* current_bucket_array;
-        volatile LONG bucket_count;
+        LONG bucket_count;
         uint64_t bucket_index;
         bool found_in_lower_levels = false;
 
         // find or allocate a new bucket array
         current_bucket_array = get_first_bucket_array(clds_hash_table);
-        bucket_count = current_bucket_array->bucket_count;
+        bucket_count = InterlockedAdd(&current_bucket_array->bucket_count, 0);
 
         (void)InterlockedIncrement(&current_bucket_array->pending_insert_count);
 
@@ -310,7 +373,7 @@ CLDS_HASH_TABLE_INSERT_RESULT clds_hash_table_insert(CLDS_HASH_TABLE_HANDLE clds
         {
             next_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&find_bucket_array->next_bucket, NULL, NULL);
 
-            bucket_index = hash % find_bucket_array->bucket_count;
+            bucket_index = hash % InterlockedAdd(&find_bucket_array->bucket_count, 0);
             bucket_list = InterlockedCompareExchangePointer(&find_bucket_array->hash_table[bucket_index], NULL, NULL);
 
             if (bucket_list != NULL)
@@ -409,20 +472,17 @@ CLDS_HASH_TABLE_INSERT_RESULT clds_hash_table_insert(CLDS_HASH_TABLE_HANDLE clds
                 }
                 else
                 {
-                    (void)InterlockedDecrement(&current_bucket_array->pending_insert_count);
-
                     /* Codes_SRS_CLDS_HASH_TABLE_01_009: [ On success clds_hash_table_insert shall return CLDS_HASH_TABLE_INSERT_OK. ]*/
                     result = CLDS_HASH_TABLE_INSERT_OK;
-
-                    goto all_ok;
                 }
             }
         }
 
         (void)InterlockedDecrement(&current_bucket_array->pending_insert_count);
-    }
 
-all_ok:
+        /* Codes_SRS_CLDS_HASH_TABLE_42_063: [ clds_hash_table_insert shall decrement the count of pending write operations. ]*/
+        end_write_operation(clds_hash_table);
+    }
     return result;
 }
 
@@ -466,6 +526,13 @@ CLDS_HASH_TABLE_DELETE_RESULT clds_hash_table_delete(CLDS_HASH_TABLE_HANDLE clds
     }
     else
     {
+        /* Codes_SRS_CLDS_HASH_TABLE_42_037: [ clds_hash_table_delete shall try the following until it acquires a write lock for the table: ]*/
+        /* Codes_SRS_CLDS_HASH_TABLE_42_038: [ clds_hash_table_delete shall increment the count of pending write operations. ]*/
+        /* Codes_SRS_CLDS_HASH_TABLE_42_039: [ If the counter to lock the table for writes is non-zero then: ]*/
+        /* Codes_SRS_CLDS_HASH_TABLE_42_040: [ clds_hash_table_delete shall decrement the count of pending write operations. ]*/
+        /* Codes_SRS_CLDS_HASH_TABLE_42_041: [ clds_hash_table_delete shall wait for the counter to lock the table for writes to reach 0 and repeat. ]*/
+        check_lock_and_begin_write_operation(clds_hash_table);
+
         CLDS_SORTED_LIST_HANDLE bucket_list;
         BUCKET_ARRAY* current_bucket_array;
 
@@ -524,6 +591,9 @@ CLDS_HASH_TABLE_DELETE_RESULT clds_hash_table_delete(CLDS_HASH_TABLE_HANDLE clds
             /* Codes_SRS_CLDS_HASH_TABLE_01_025: [ If the element to be deleted is not found in an array of buckets, then it shall be looked up in the next available array of buckets. ] */
             current_bucket_array = next_bucket_array;
         }
+
+        /* Codes_SRS_CLDS_HASH_TABLE_42_042: [ clds_hash_table_insert shall decrement the count of pending write operations. ]*/
+        end_write_operation(clds_hash_table);
     }
 
     return result;
@@ -552,6 +622,13 @@ CLDS_HASH_TABLE_DELETE_RESULT clds_hash_table_delete_key_value(CLDS_HASH_TABLE_H
     }
     else
     {
+        /* Codes_SRS_CLDS_HASH_TABLE_42_043: [ clds_hash_table_delete_key_value shall try the following until it acquires a write lock for the table: ]*/
+        /* Codes_SRS_CLDS_HASH_TABLE_42_044: [ clds_hash_table_delete_key_value shall increment the count of pending write operations. ]*/
+        /* Codes_SRS_CLDS_HASH_TABLE_42_045: [ If the counter to lock the table for writes is non-zero then: ]*/
+        /* Codes_SRS_CLDS_HASH_TABLE_42_046: [ clds_hash_table_delete_key_value shall decrement the count of pending write operations. ]*/
+        /* Codes_SRS_CLDS_HASH_TABLE_42_047: [ clds_hash_table_delete_key_value shall wait for the counter to lock the table for writes to reach 0 and repeat. ]*/
+        check_lock_and_begin_write_operation(clds_hash_table);
+
         CLDS_SORTED_LIST_HANDLE bucket_list;
         BUCKET_ARRAY* current_bucket_array;
 
@@ -609,6 +686,9 @@ CLDS_HASH_TABLE_DELETE_RESULT clds_hash_table_delete_key_value(CLDS_HASH_TABLE_H
             /*Codes_SRS_CLDS_HASH_TABLE_42_010: [ If the element to be deleted is not found in an array of buckets, then clds_hash_table_delete_key_value shall look in the next available array of buckets. ]*/
             current_bucket_array = next_bucket_array;
         }
+
+        /* Codes_SRS_CLDS_HASH_TABLE_42_048: [ clds_hash_table_delete_key_value shall decrement the count of pending write operations. ]*/
+        end_write_operation(clds_hash_table);
     }
 
     return result;
@@ -637,6 +717,13 @@ CLDS_HASH_TABLE_REMOVE_RESULT clds_hash_table_remove(CLDS_HASH_TABLE_HANDLE clds
     }
     else
     {
+        /* Codes_SRS_CLDS_HASH_TABLE_42_049: [ clds_hash_table_remove shall try the following until it acquires a write lock for the table: ]*/
+        /* Codes_SRS_CLDS_HASH_TABLE_42_050: [ clds_hash_table_remove shall increment the count of pending write operations. ]*/
+        /* Codes_SRS_CLDS_HASH_TABLE_42_051: [ If the counter to lock the table for writes is non-zero then: ]*/
+        /* Codes_SRS_CLDS_HASH_TABLE_42_052: [ clds_hash_table_remove shall decrement the count of pending write operations. ]*/
+        /* Codes_SRS_CLDS_HASH_TABLE_42_053: [ clds_hash_table_remove shall wait for the counter to lock the table for writes to reach 0 and repeat. ]*/
+        check_lock_and_begin_write_operation(clds_hash_table);
+
         CLDS_SORTED_LIST_HANDLE bucket_list;
         BUCKET_ARRAY* current_bucket_array;
 
@@ -694,6 +781,9 @@ CLDS_HASH_TABLE_REMOVE_RESULT clds_hash_table_remove(CLDS_HASH_TABLE_HANDLE clds
             /* Codes_SRS_CLDS_HASH_TABLE_01_055: [ If the element to be deleted is not found in the biggest array of buckets, then it shall be looked up in the next available array of buckets. ]*/
             current_bucket_array = next_bucket_array;
         }
+
+        /* Codes_SRS_CLDS_HASH_TABLE_42_054: [ clds_hash_table_remove shall decrement the count of pending write operations. ]*/
+        end_write_operation(clds_hash_table);
     }
 
     return result;
@@ -724,6 +814,13 @@ CLDS_HASH_TABLE_SET_VALUE_RESULT clds_hash_table_set_value(CLDS_HASH_TABLE_HANDL
     }
     else
     {
+        /* Codes_SRS_CLDS_HASH_TABLE_42_055: [ clds_hash_table_set_value shall try the following until it acquires a write lock for the table: ]*/
+        /* Codes_SRS_CLDS_HASH_TABLE_42_056: [ clds_hash_table_set_value shall increment the count of pending write operations. ]*/
+        /* Codes_SRS_CLDS_HASH_TABLE_42_057: [ If the counter to lock the table for writes is non-zero then: ]*/
+        /* Codes_SRS_CLDS_HASH_TABLE_42_058: [ clds_hash_table_set_value shall decrement the count of pending write operations. ]*/
+        /* Codes_SRS_CLDS_HASH_TABLE_42_059: [ clds_hash_table_set_value shall wait for the counter to lock the table for writes to reach 0 and repeat. ]*/
+        check_lock_and_begin_write_operation(clds_hash_table);
+
         // compute the hash
         uint64_t hash = clds_hash_table->compute_hash(key);
 
@@ -849,6 +946,9 @@ CLDS_HASH_TABLE_SET_VALUE_RESULT clds_hash_table_set_value(CLDS_HASH_TABLE_HANDL
         }
 
         (void)InterlockedDecrement(&first_bucket_array->pending_insert_count);
+
+        /* Codes_SRS_CLDS_HASH_TABLE_42_060: [ clds_hash_table_set_value shall decrement the count of pending write operations. ]*/
+        end_write_operation(clds_hash_table);
     }
 
     return result;
@@ -924,6 +1024,247 @@ CLDS_HASH_TABLE_ITEM* clds_hash_table_find(CLDS_HASH_TABLE_HANDLE clds_hash_tabl
         {
             // all OK
         }
+    }
+
+    return result;
+}
+
+CLDS_HASH_TABLE_SNAPSHOT_RESULT clds_hash_table_snapshot(CLDS_HASH_TABLE_HANDLE clds_hash_table, CLDS_HAZARD_POINTERS_THREAD_HANDLE clds_hazard_pointers_thread, CLDS_HASH_TABLE_ITEM*** items, uint64_t* item_count)
+{
+    CLDS_HASH_TABLE_SNAPSHOT_RESULT result;
+
+    if (
+        /* Codes_SRS_CLDS_HASH_TABLE_42_013: [ If clds_hash_table is NULL then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
+        (clds_hash_table == NULL) ||
+        /* Codes_SRS_CLDS_HASH_TABLE_42_014: [ If clds_hazard_pointers_thread is NULL then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
+        (clds_hazard_pointers_thread == NULL) ||
+        /* Codes_SRS_CLDS_HASH_TABLE_42_015: [ If items is NULL then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
+        (items == NULL) ||
+        /* Codes_SRS_CLDS_HASH_TABLE_42_016: [ If item_count is NULL then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
+        (item_count == NULL)
+        )
+    {
+        LogError("Invalid arguments: CLDS_HASH_TABLE_HANDLE clds_hash_table=%p, CLDS_HAZARD_POINTERS_THREAD_HANDLE clds_hazard_pointers_thread=%p, CLDS_HASH_TABLE_ITEM** items=%p, uint64_t* item_count=%p",
+            clds_hash_table, clds_hazard_pointers_thread, items, item_count);
+        result = CLDS_HASH_TABLE_SNAPSHOT_ERROR;
+    }
+    else
+    {
+        internal_lock_writes(clds_hash_table);
+
+        uint64_t temp_item_count = 0;
+        bool failed = false;
+        bool need_to_unlock_all = false;
+
+        /* Codes_SRS_CLDS_HASH_TABLE_42_019: [ For each bucket in the array: ]*/
+        BUCKET_ARRAY* current_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&clds_hash_table->first_hash_table, NULL, NULL);
+        while (current_bucket_array != NULL)
+        {
+            BUCKET_ARRAY* next_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&current_bucket_array->next_bucket, NULL, NULL);
+
+            if (InterlockedAdd(&current_bucket_array->item_count, 0) != 0)
+            {
+                LONG bucket_count = InterlockedAdd(&current_bucket_array->bucket_count, 0);
+                LONG i;
+                for (i = 0; i < bucket_count; i++)
+                {
+                    if (current_bucket_array->hash_table[i] != NULL)
+                    {
+                        /* Codes_SRS_CLDS_HASH_TABLE_42_020: [ clds_hash_table_snapshot shall call clds_sorted_list_lock_writes. ]*/
+                        clds_sorted_list_lock_writes(current_bucket_array->hash_table[i]);
+                        need_to_unlock_all = true;
+
+                        /* Codes_SRS_CLDS_HASH_TABLE_42_021: [ clds_hash_table_snapshot shall call clds_sorted_list_get_count and add to the running total. ]*/
+                        uint64_t list_item_count;
+                        CLDS_SORTED_LIST_GET_COUNT_RESULT count_result = clds_sorted_list_get_count(current_bucket_array->hash_table[i], clds_hazard_pointers_thread, &list_item_count);
+                        if (count_result != CLDS_SORTED_LIST_GET_COUNT_OK)
+                        {
+                            /* Codes_SRS_CLDS_HASH_TABLE_42_061: [ If there are any other failures then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
+                            LogError("clds_sorted_list_get_count failed with %" PRI_MU_ENUM, MU_ENUM_VALUE(CLDS_SORTED_LIST_GET_COUNT_RESULT, count_result));
+                            clds_sorted_list_unlock_writes(current_bucket_array->hash_table[i]);
+                            break;
+                        }
+                        else
+                        {
+                            if (list_item_count + temp_item_count < temp_item_count)
+                            {
+                                /* Codes_SRS_CLDS_HASH_TABLE_42_022: [ If the addition of the list count causes overflow then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
+                                LogError("overflow in computing total count (%" PRIu64 " + %" PRIu64 ")", temp_item_count, list_item_count);
+                                clds_sorted_list_unlock_writes(current_bucket_array->hash_table[i]);
+                                break;
+                            }
+                            else
+                            {
+                                temp_item_count += list_item_count;
+                            }
+                        }
+                    }
+                }
+
+                if (i < bucket_count)
+                {
+                    for (LONG index_to_clean = 0; index_to_clean < i; index_to_clean++)
+                    {
+                        if (current_bucket_array->hash_table[index_to_clean] != NULL)
+                        {
+                            clds_sorted_list_unlock_writes(current_bucket_array->hash_table[index_to_clean]);
+                        }
+                    }
+                    failed = true;
+                    break;
+                }
+            }
+
+            current_bucket_array = next_bucket_array;
+        }
+
+        if (failed)
+        {
+            result = CLDS_HASH_TABLE_SNAPSHOT_ERROR;
+        }
+        else if (temp_item_count > SIZE_MAX / sizeof(CLDS_SORTED_LIST_ITEM*))
+        {
+            /* Codes_SRS_CLDS_HASH_TABLE_42_062: [ If the number of items multiplied by the size of CLDS_HASH_TABLE_ITEM exceeds SIZE_MAX then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
+            LogError("Unable to allocate array of %zu items, requires more than %zu bytes", temp_item_count, SIZE_MAX);
+            result = CLDS_HASH_TABLE_SNAPSHOT_ERROR;
+        }
+        else
+        {
+            if (temp_item_count == 0)
+            {
+                /* Codes_SRS_CLDS_HASH_TABLE_42_064: [ If there are no items then clds_hash_table_snapshot shall set items to NULL and item_count to 0 and return CLDS_HASH_TABLE_SNAPSHOT_OK. ]*/
+                *items = NULL;
+                *item_count = 0;
+                result = CLDS_HASH_TABLE_SNAPSHOT_OK;
+            }
+            else
+            {
+                /* Codes_SRS_CLDS_HASH_TABLE_42_023: [ clds_hash_table_snapshot shall allocate an array of CLDS_HASH_TABLE_ITEM* ]*/
+                CLDS_SORTED_LIST_ITEM** items_to_return = malloc(sizeof(CLDS_SORTED_LIST_ITEM*) * temp_item_count);
+
+                if (items_to_return == NULL)
+                {
+                    /* Codes_SRS_CLDS_HASH_TABLE_42_061: [ If there are any other failures then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
+                    LogError("malloc(%zu) failed for the items to return", sizeof(CLDS_SORTED_LIST_ITEM*) * temp_item_count);
+                    result = CLDS_HASH_TABLE_SNAPSHOT_ERROR;
+                }
+                else
+                {
+                    uint64_t result_index = 0;
+
+                    /* Codes_SRS_CLDS_HASH_TABLE_42_024: [ For each bucket in the array: ]*/
+                    current_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&clds_hash_table->first_hash_table, NULL, NULL);
+                    while (current_bucket_array != NULL)
+                    {
+                        BUCKET_ARRAY* next_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&current_bucket_array->next_bucket, NULL, NULL);
+
+                        if (InterlockedAdd(&current_bucket_array->item_count, 0) != 0)
+                        {
+                            LONG bucket_count = InterlockedAdd(&current_bucket_array->bucket_count, 0);
+                            LONG i;
+                            for (i = 0; i < bucket_count; i++)
+                            {
+                                if (current_bucket_array->hash_table[i] != NULL)
+                                {
+                                    if (!failed)
+                                    {
+                                        /* Codes_SRS_CLDS_HASH_TABLE_42_025: [ clds_hash_table_snapshot shall call clds_sorted_list_get_count. ]*/
+                                        uint64_t list_item_count;
+                                        CLDS_SORTED_LIST_GET_COUNT_RESULT count_result = clds_sorted_list_get_count(current_bucket_array->hash_table[i], clds_hazard_pointers_thread, &list_item_count);
+                                        if (count_result != CLDS_SORTED_LIST_GET_COUNT_OK)
+                                        {
+                                            /* Codes_SRS_CLDS_HASH_TABLE_42_061: [ If there are any other failures then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
+                                            LogError("clds_sorted_list_get_count failed with %" PRI_MU_ENUM, MU_ENUM_VALUE(CLDS_SORTED_LIST_GET_COUNT_RESULT, count_result));
+                                            failed = true;
+                                        }
+                                        else
+                                        {
+                                            if (list_item_count == 0)
+                                            {
+                                                // skip
+                                            }
+                                            else
+                                            {
+                                                /* Codes_SRS_CLDS_HASH_TABLE_42_026: [ clds_hash_table_snapshot shall call clds_sorted_list_get_all with the next portion of the allocated array. ]*/
+                                                CLDS_SORTED_LIST_GET_ALL_RESULT get_all_result = clds_sorted_list_get_all(current_bucket_array->hash_table[i], clds_hazard_pointers_thread, list_item_count, items_to_return + result_index);
+                                                if (get_all_result != CLDS_SORTED_LIST_GET_ALL_OK)
+                                                {
+                                                    /* Codes_SRS_CLDS_HASH_TABLE_42_061: [ If there are any other failures then clds_hash_table_snapshot shall fail and return CLDS_HASH_TABLE_SNAPSHOT_ERROR. ]*/
+                                                    LogError("clds_sorted_list_get_all failed with %" PRI_MU_ENUM, MU_ENUM_VALUE(CLDS_SORTED_LIST_GET_ALL_RESULT, get_all_result));
+                                                    failed = true;
+                                                }
+                                                else
+                                                {
+                                                    result_index += list_item_count;
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    /* Codes_SRS_CLDS_HASH_TABLE_42_027: [ clds_hash_table_snapshot shall call clds_sorted_list_unlock_writes. ]*/
+                                    clds_sorted_list_unlock_writes(current_bucket_array->hash_table[i]);
+                                }
+                            }
+                        }
+
+                        current_bucket_array = next_bucket_array;
+                    }
+
+                    need_to_unlock_all = false; // Unlocked
+
+                    if (failed)
+                    {
+                        result = CLDS_HASH_TABLE_SNAPSHOT_ERROR;
+
+                        for (uint64_t i = 0; i < result_index; i++)
+                        {
+                            clds_sorted_list_node_release(items_to_return[i]);
+                        }
+                        free(items_to_return);
+                    }
+                    else
+                    {
+                        /* Codes_SRS_CLDS_HASH_TABLE_42_028: [ clds_hash_table_snapshot shall store the allocated array of items in items. ]*/
+                        *items = (CLDS_HASH_TABLE_ITEM**)items_to_return;
+                        items_to_return = NULL;
+
+                        /* Codes_SRS_CLDS_HASH_TABLE_42_029: [ clds_hash_table_snapshot shall store the count of items in item_count. ]*/
+                        *item_count = result_index;
+
+                        /* Codes_SRS_CLDS_HASH_TABLE_42_031: [ clds_hash_table_snapshot shall succeed and return CLDS_HASH_TABLE_SNAPSHOT_OK. ]*/
+                        result = CLDS_HASH_TABLE_SNAPSHOT_OK;
+                    }
+                }
+            }
+        }
+
+        if (need_to_unlock_all)
+        {
+            // Unlock all the lists that have been locked so far
+            // If we only looked at part of the table, the old "current_bucket_array" is already in a cleaned up state
+            // Otherwise it is NULL and we will unlock everything
+            BUCKET_ARRAY* bucket_array_to_clean = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&clds_hash_table->first_hash_table, NULL, NULL);
+            while (bucket_array_to_clean != current_bucket_array)
+            {
+                BUCKET_ARRAY* next_bucket_array = (BUCKET_ARRAY*)InterlockedCompareExchangePointer((volatile PVOID*)&bucket_array_to_clean->next_bucket, NULL, NULL);
+
+                if (InterlockedAdd(&bucket_array_to_clean->item_count, 0) != 0)
+                {
+                    LONG bucket_count = InterlockedAdd(&bucket_array_to_clean->bucket_count, 0);
+                    for (LONG i = 0; i < bucket_count; i++)
+                    {
+                        if (bucket_array_to_clean->hash_table[i] != NULL)
+                        {
+                            clds_sorted_list_unlock_writes(bucket_array_to_clean->hash_table[i]);
+                        }
+                    }
+                }
+
+                bucket_array_to_clean = next_bucket_array;
+            }
+        }
+
+        internal_unlock_writes(clds_hash_table);
     }
 
     return result;

--- a/src/clds_sorted_list.c
+++ b/src/clds_sorted_list.c
@@ -12,6 +12,9 @@
 #include "clds/clds_atomics.h"
 #include "clds/clds_hazard_pointers.h"
 
+MU_DEFINE_ENUM_STRINGS(CLDS_SORTED_LIST_GET_COUNT_RESULT, CLDS_SORTED_LIST_GET_COUNT_RESULT_VALUES);
+MU_DEFINE_ENUM_STRINGS(CLDS_SORTED_LIST_GET_ALL_RESULT, CLDS_SORTED_LIST_GET_ALL_RESULT_VALUES);
+
 /* this is a lock free sorted list implementation */
 
 typedef struct CLDS_SORTED_LIST_TAG

--- a/tests/clds_hash_table_int/clds_hash_table_int.c
+++ b/tests/clds_hash_table_int/clds_hash_table_int.c
@@ -36,8 +36,11 @@ TEST_DEFINE_ENUM_TYPE(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_RESU
 TEST_DEFINE_ENUM_TYPE(CLDS_HASH_TABLE_DELETE_RESULT, CLDS_HASH_TABLE_DELETE_RESULT_VALUES);
 TEST_DEFINE_ENUM_TYPE(CLDS_HASH_TABLE_REMOVE_RESULT, CLDS_HASH_TABLE_REMOVE_RESULT_VALUES);
 TEST_DEFINE_ENUM_TYPE(CLDS_HASH_TABLE_SET_VALUE_RESULT, CLDS_HASH_TABLE_SET_VALUE_RESULT_VALUES);
+TEST_DEFINE_ENUM_TYPE(CLDS_HASH_TABLE_SNAPSHOT_RESULT, CLDS_HASH_TABLE_SNAPSHOT_RESULT_VALUES);
 
 MU_DEFINE_ENUM_STRINGS(UMOCK_C_ERROR_CODE, UMOCK_C_ERROR_CODE_VALUES)
+
+#define THREAD_COUNT 4
 
 static void on_umock_c_error(UMOCK_C_ERROR_CODE error_code)
 {
@@ -47,6 +50,7 @@ static void on_umock_c_error(UMOCK_C_ERROR_CODE error_code)
 typedef struct TEST_ITEM_TAG
 {
     uint32_t key;
+    uint32_t appendix;
 } TEST_ITEM;
 
 DECLARE_HASH_TABLE_NODE_TYPE(TEST_ITEM)
@@ -83,10 +87,373 @@ static void test_skipped_seq_no_cb(void* context, int64_t skipped_sequence_no)
     (void)skipped_sequence_no;
 }
 
+static void test_skipped_seq_no_ignore(void* context, int64_t skipped_sequence_no)
+{
+    (void)context;
+    (void)skipped_sequence_no;
+}
+
 static void test_item_cleanup_func(void* context, struct CLDS_HASH_TABLE_ITEM_TAG* item)
 {
     (void)context;
     (void)item;
+}
+
+typedef struct SHARED_KEY_INFO_TAG
+{
+    volatile LONG last_written_key;
+} SHARED_KEY_INFO;
+
+typedef struct THREAD_DATA_TAG
+{
+    CLDS_HASH_TABLE_HANDLE hash_table;
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE clds_hazard_pointers_thread;
+    volatile LONG stop;
+    uint32_t key;
+    uint32_t increment;
+    SHARED_KEY_INFO* shared;
+} THREAD_DATA;
+
+static void initialize_thread_data(THREAD_DATA* thread_data, SHARED_KEY_INFO* shared, CLDS_HASH_TABLE_HANDLE hash_table, CLDS_HAZARD_POINTERS_HANDLE hazard_pointers, uint32_t starting_key, uint32_t increment)
+{
+    thread_data->hash_table = hash_table;
+    thread_data->clds_hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    ASSERT_IS_NOT_NULL(thread_data->clds_hazard_pointers_thread);
+    thread_data->key = starting_key;
+    thread_data->increment = increment;
+    (void)InterlockedExchange(&thread_data->stop, 0);
+    thread_data->shared = shared;
+}
+
+static int continuous_insert_thread(void* arg)
+{
+    THREAD_DATA* thread_data = (THREAD_DATA*)arg;
+    int result;
+
+    uint32_t i = thread_data->key;
+
+    do
+    {
+        CLDS_HASH_TABLE_INSERT_RESULT insert_result;
+        CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, NULL, NULL);
+        TEST_ITEM* test_item = CLDS_HASH_TABLE_GET_VALUE(TEST_ITEM, item);
+        test_item->key = i;
+        int64_t insert_seq_no;
+        insert_result = clds_hash_table_insert(thread_data->hash_table, thread_data->clds_hazard_pointers_thread, (void*)(INT_PTR)(i + 1), item, &insert_seq_no);
+        ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, insert_result);
+
+        (void)InterlockedExchange(&thread_data->shared->last_written_key, (LONG)i);
+
+        i += thread_data->increment;
+    } while (InterlockedAdd(&thread_data->stop, 0) == 0);
+
+    result = 0;
+
+    ThreadAPI_Exit(result);
+    return result;
+}
+
+static int continuous_delete_thread(void* arg)
+{
+    THREAD_DATA* thread_data = (THREAD_DATA*)arg;
+    int result;
+
+    uint32_t i = thread_data->key;
+
+    do
+    {
+        while ((uint32_t)InterlockedAdd(&thread_data->shared->last_written_key, 0) < i)
+        {
+            if (InterlockedAdd(&thread_data->stop, 0) != 0)
+            {
+                // Don't wait forever if the insert thread isn't running any more
+                break;
+            }
+            // Spin
+        }
+
+        if (InterlockedAdd(&thread_data->stop, 0) != 0)
+        {
+            break;
+        }
+
+        CLDS_HASH_TABLE_DELETE_RESULT delete_result;
+        int64_t seq_no;
+        delete_result = clds_hash_table_delete(thread_data->hash_table, thread_data->clds_hazard_pointers_thread, (void*)(INT_PTR)(i + 1), &seq_no);
+        ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_DELETE_RESULT, CLDS_HASH_TABLE_DELETE_OK, delete_result);
+
+        i += thread_data->increment;
+    } while (InterlockedAdd(&thread_data->stop, 0) == 0);
+
+    result = 0;
+
+    ThreadAPI_Exit(result);
+    return result;
+}
+
+static int continuous_delete_key_value_thread(void* arg)
+{
+    THREAD_DATA* thread_data = (THREAD_DATA*)arg;
+    int result;
+
+    uint32_t i = thread_data->key;
+
+    do
+    {
+        while ((uint32_t)InterlockedAdd(&thread_data->shared->last_written_key, 0) < i)
+        {
+            if (InterlockedAdd(&thread_data->stop, 0) != 0)
+            {
+                // Don't wait forever if the insert thread isn't running any more
+                break;
+            }
+            // Spin
+        }
+
+        if (InterlockedAdd(&thread_data->stop, 0) != 0)
+        {
+            break;
+        }
+
+        // To simplify a bit, we actually first do a find and then delete by the value we found
+        // Otherwise, we would need to share the item pointers between the insert and delete threads which adds complexity
+
+        CLDS_HASH_TABLE_ITEM* item = clds_hash_table_find(thread_data->hash_table, thread_data->clds_hazard_pointers_thread, (void*)(INT_PTR)(i + 1));
+        ASSERT_IS_NOT_NULL(item);
+
+        CLDS_HASH_TABLE_DELETE_RESULT delete_result;
+        int64_t seq_no;
+        delete_result = clds_hash_table_delete_key_value(thread_data->hash_table, thread_data->clds_hazard_pointers_thread, (void*)(INT_PTR)(i + 1), item, &seq_no);
+        ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_DELETE_RESULT, CLDS_HASH_TABLE_DELETE_OK, delete_result);
+
+        CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, item);
+
+        i += thread_data->increment;
+    } while (InterlockedAdd(&thread_data->stop, 0) == 0);
+
+    result = 0;
+
+    ThreadAPI_Exit(result);
+    return result;
+}
+
+static int continuous_remove_thread(void* arg)
+{
+    THREAD_DATA* thread_data = (THREAD_DATA*)arg;
+    int result;
+
+    uint32_t i = thread_data->key;
+
+    do
+    {
+        while ((uint32_t)InterlockedAdd(&thread_data->shared->last_written_key, 0) < i)
+        {
+            if (InterlockedAdd(&thread_data->stop, 0) != 0)
+            {
+                // Don't wait forever if the insert thread isn't running any more
+                break;
+            }
+            // Spin
+        }
+
+        if (InterlockedAdd(&thread_data->stop, 0) != 0)
+        {
+            break;
+        }
+
+        CLDS_HASH_TABLE_ITEM* item;
+        CLDS_HASH_TABLE_REMOVE_RESULT remove_result;
+        int64_t seq_no;
+        remove_result = clds_hash_table_remove(thread_data->hash_table, thread_data->clds_hazard_pointers_thread, (void*)(INT_PTR)(i + 1), &item, &seq_no);
+        ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_REMOVE_RESULT, CLDS_HASH_TABLE_REMOVE_OK, remove_result);
+
+        CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, item);
+
+        i += thread_data->increment;
+    } while (InterlockedAdd(&thread_data->stop, 0) == 0);
+
+    result = 0;
+
+    ThreadAPI_Exit(result);
+    return result;
+}
+
+static int continuous_set_value_thread(void* arg)
+{
+    THREAD_DATA* thread_data = (THREAD_DATA*)arg;
+    int result;
+
+    uint32_t i = thread_data->key;
+    uint32_t appendix = 4242;
+
+    do
+    {
+        // Just loop over everything forever, re-setting the values
+        if ((uint32_t)InterlockedAdd(&thread_data->shared->last_written_key, 0) < i)
+        {
+            i = thread_data->key;
+            appendix++;
+        }
+
+        CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, NULL, NULL);
+        TEST_ITEM* test_item = CLDS_HASH_TABLE_GET_VALUE(TEST_ITEM, item);
+        test_item->key = i;
+        test_item->appendix = appendix;
+
+        CLDS_HASH_TABLE_ITEM* old_item;
+        CLDS_HASH_TABLE_SET_VALUE_RESULT set_result;
+        int64_t seq_no;
+        set_result = clds_hash_table_set_value(thread_data->hash_table, thread_data->clds_hazard_pointers_thread, (void*)(INT_PTR)(i + 1), item, &old_item, &seq_no);
+        ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_SET_VALUE_RESULT, CLDS_HASH_TABLE_SET_VALUE_OK, set_result);
+
+        CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, old_item);
+
+        i += thread_data->increment;
+    } while (InterlockedAdd(&thread_data->stop, 0) == 0);
+
+    result = 0;
+
+    ThreadAPI_Exit(result);
+    return result;
+}
+
+static int continuous_find_thread(void* arg)
+{
+    THREAD_DATA* thread_data = (THREAD_DATA*)arg;
+    int result;
+
+    uint32_t i = thread_data->key;
+
+    do
+    {
+        // Just loop over everything forever
+        if ((uint32_t)InterlockedAdd(&thread_data->shared->last_written_key, 0) < i)
+        {
+            i = thread_data->key;
+        }
+
+        CLDS_HASH_TABLE_ITEM* item = clds_hash_table_find(thread_data->hash_table, thread_data->clds_hazard_pointers_thread, (void*)(INT_PTR)(i + 1));
+        ASSERT_IS_NOT_NULL(item);
+
+        CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, item);
+
+        i += thread_data->increment;
+    } while (InterlockedAdd(&thread_data->stop, 0) == 0);
+
+    result = 0;
+
+    ThreadAPI_Exit(result);
+    return result;
+}
+
+
+
+static void fill_hash_table_sequentially(CLDS_HASH_TABLE_HANDLE hash_table, CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread, uint32_t count)
+{
+    for (uint32_t i = 0; i < count; i++)
+    {
+        CLDS_HASH_TABLE_INSERT_RESULT result;
+        CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, NULL, NULL);
+        TEST_ITEM* test_item = CLDS_HASH_TABLE_GET_VALUE(TEST_ITEM, item);
+        test_item->key = i;
+        test_item->appendix = 42;
+        int64_t insert_seq_no;
+        result = clds_hash_table_insert(hash_table, hazard_pointers_thread, (void*)(INT_PTR)(i + 1), item, &insert_seq_no);
+        ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_INSERT_RESULT, CLDS_HASH_TABLE_INSERT_OK, result);
+    }
+}
+
+static void verify_all_items_present(uint32_t expected_count, CLDS_HASH_TABLE_ITEM** items, uint64_t actual_count)
+{
+    ASSERT_ARE_EQUAL(uint64_t, (uint64_t)expected_count, actual_count);
+
+    bool* found_array = (bool*)malloc(sizeof(bool) * expected_count);
+    ASSERT_IS_NOT_NULL(found_array);
+
+    for (uint32_t expected_index = 0; expected_index < expected_count; expected_index++)
+    {
+        found_array[expected_index] = false;
+    }
+
+    for (uint32_t actual_index = 0; actual_index < (uint32_t)actual_count; actual_index++)
+    {
+        TEST_ITEM* test_item = CLDS_HASH_TABLE_GET_VALUE(TEST_ITEM, items[actual_index]);
+
+        if (test_item->key >= expected_count)
+        {
+            ASSERT_FAIL("Found invalid key %" PRIu32 " max expected key was %" PRIu32, test_item->key, expected_count - 1);
+        }
+        else
+        {
+            if (found_array[test_item->key])
+            {
+                ASSERT_FAIL("Found duplicate item with key %" PRIu32, test_item->key);
+            }
+            else
+            {
+                found_array[test_item->key] = true;
+            }
+        }
+    }
+
+    for (uint64_t expected_index = 0; expected_index < expected_count; expected_index++)
+    {
+        ASSERT_IS_TRUE(found_array[expected_index], "Should have found item with key %" PRIu64, expected_index);
+    }
+
+    free(found_array);
+}
+
+static void verify_all_items_present_ignore_extras(uint32_t expected_count, CLDS_HASH_TABLE_ITEM** items, uint64_t actual_count)
+{
+    ASSERT_IS_TRUE((uint64_t)expected_count <= actual_count);
+
+    bool* found_array = (bool*)malloc(sizeof(bool) * expected_count);
+    ASSERT_IS_NOT_NULL(found_array);
+
+    for (uint32_t expected_index = 0; expected_index < expected_count; expected_index++)
+    {
+        found_array[expected_index] = false;
+    }
+
+    for (uint32_t actual_index = 0; actual_index < (uint32_t)actual_count; actual_index++)
+    {
+        TEST_ITEM* test_item = CLDS_HASH_TABLE_GET_VALUE(TEST_ITEM, items[actual_index]);
+
+        if (test_item->key >= expected_count)
+        {
+            // Ignore extra items
+            continue;
+        }
+        else
+        {
+            if (found_array[test_item->key])
+            {
+                // Ignore duplicates
+                continue;
+            }
+            else
+            {
+                found_array[test_item->key] = true;
+            }
+        }
+    }
+
+    for (uint64_t expected_index = 0; expected_index < expected_count; expected_index++)
+    {
+        ASSERT_IS_TRUE(found_array[expected_index], "Should have found item with key %" PRIu64, expected_index);
+    }
+
+    free(found_array);
+}
+
+static void cleanup_snapshot(CLDS_HASH_TABLE_ITEM** items, uint64_t item_count)
+{
+    for (uint64_t i = 0; i < item_count; i++)
+    {
+        CLDS_HASH_TABLE_NODE_RELEASE(TEST_ITEM, items[i]);
+    }
+    free(items);
 }
 
 BEGIN_TEST_SUITE(clds_hash_table_inttests)
@@ -232,7 +599,7 @@ TEST_FUNCTION(clds_hash_table_set_value_succeeds)
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, NULL, NULL);
     CLDS_HASH_TABLE_ITEM* old_item;
     int64_t set_value_seq_no;
-    
+
     // act
     set_value_result = clds_hash_table_set_value(hash_table, hazard_pointers_thread, (void*)0x42, item, &old_item, &set_value_seq_no);
 
@@ -309,6 +676,532 @@ TEST_FUNCTION(clds_hash_table_delete_after_set_value_succeeds)
     ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_DELETE_RESULT, CLDS_HASH_TABLE_DELETE_OK, delete_result, "item delete failed");
 
     // cleanup
+    clds_hash_table_destroy(hash_table);
+    clds_hazard_pointers_destroy(hazard_pointers);
+}
+
+TEST_FUNCTION(clds_hash_table_snapshot_works_with_10000_sequential_key_items)
+{
+    // arrange
+    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    volatile int64_t sequence_number = 45;
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 1, hazard_pointers, &sequence_number, test_skipped_seq_no_cb, (void*)0x5556);
+
+    uint32_t original_count = 10000;
+    fill_hash_table_sequentially(hash_table, hazard_pointers_thread, original_count);
+
+    CLDS_HASH_TABLE_ITEM** items;
+    uint64_t item_count;
+
+    // act
+    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, hazard_pointers_thread, &items, &item_count);
+
+    // assert
+    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_SNAPSHOT_RESULT, CLDS_HASH_TABLE_SNAPSHOT_OK, result);
+    verify_all_items_present(original_count, items, item_count);
+
+    // cleanup
+    cleanup_snapshot(items, item_count);
+    clds_hash_table_destroy(hash_table);
+    clds_hazard_pointers_destroy(hazard_pointers);
+}
+
+/* Tests_SRS_CLDS_HASH_TABLE_42_017: [ clds_hash_table_snapshot shall increment a counter to lock the table for writes. ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_018: [ clds_hash_table_snapshot shall wait for the ongoing write operations to complete. ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_030: [ clds_hash_table_snapshot shall decrement the counter to unlock the table for writes. ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_032: [ clds_hash_table_insert shall try the following until it acquires a write lock for the table: ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_033: [ clds_hash_table_insert shall increment the count of pending write operations. ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_034: [ If the counter to lock the table for writes is non-zero then: ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_035: [ clds_hash_table_insert shall decrement the count of pending write operations. ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_036: [ clds_hash_table_insert shall wait for the counter to lock the table for writes to reach 0 and repeat. ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_063: [ clds_hash_table_insert shall decrement the count of pending write operations. ]*/
+TEST_FUNCTION(clds_hash_table_snapshot_works_with_concurrent_inserts)
+{
+    // arrange
+    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    volatile int64_t sequence_number = 45;
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 1, hazard_pointers, &sequence_number, test_skipped_seq_no_cb, (void*)0x5556);
+
+    uint32_t original_count = 10000;
+    fill_hash_table_sequentially(hash_table, hazard_pointers_thread, original_count);
+
+    // Start a thread to insert additional items
+    THREAD_DATA thread_data;
+    THREAD_HANDLE thread;
+    SHARED_KEY_INFO shared;
+
+    (void)InterlockedExchange(&shared.last_written_key, original_count - 1);
+    initialize_thread_data(&thread_data, &shared, hash_table, hazard_pointers, original_count, 1);
+
+    if (ThreadAPI_Create(&thread, continuous_insert_thread, &thread_data) != THREADAPI_OK)
+    {
+        ASSERT_FAIL("Error spawning insert test thread");
+    }
+
+    // Make sure inserts have started
+    ThreadAPI_Sleep(1000);
+
+    CLDS_HASH_TABLE_ITEM** items;
+    uint64_t item_count;
+
+    // act
+    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, hazard_pointers_thread, &items, &item_count);
+
+    // Inserts continue to run a bit longer to make sure we are in a good state
+    ThreadAPI_Sleep(1000);
+
+    // Stop inserts
+    (void)InterlockedExchange(&thread_data.stop, 1);
+
+    // assert
+    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_SNAPSHOT_RESULT, CLDS_HASH_TABLE_SNAPSHOT_OK, result);
+    verify_all_items_present_ignore_extras(original_count, items, item_count);
+
+    int thread_result;
+    (void)ThreadAPI_Join(thread, &thread_result);
+    ASSERT_ARE_EQUAL(int, 0, thread_result);
+
+    // cleanup
+    cleanup_snapshot(items, item_count);
+    clds_hash_table_destroy(hash_table);
+    clds_hazard_pointers_destroy(hazard_pointers);
+}
+
+TEST_FUNCTION(clds_hash_table_snapshot_works_with_multiple_concurrent_inserts)
+{
+    // arrange
+    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    volatile int64_t sequence_number = 45;
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 1, hazard_pointers, &sequence_number, test_skipped_seq_no_cb, (void*)0x5556);
+
+    uint32_t original_count = 10000;
+    fill_hash_table_sequentially(hash_table, hazard_pointers_thread, original_count);
+
+    // Start threads to insert additional items
+    THREAD_DATA thread_data[THREAD_COUNT];
+    THREAD_HANDLE thread[THREAD_COUNT];
+    SHARED_KEY_INFO shared[THREAD_COUNT];
+
+    for (uint32_t i = 0; i < THREAD_COUNT; i++)
+    {
+        (void)InterlockedExchange(&shared[i].last_written_key, original_count - 1);
+
+        initialize_thread_data(&thread_data[i], &shared[i], hash_table, hazard_pointers, original_count + i, THREAD_COUNT);
+
+        if (ThreadAPI_Create(&thread[i], continuous_insert_thread, &thread_data[i]) != THREADAPI_OK)
+        {
+            ASSERT_FAIL("Error spawning insert test thread %" PRIu32, i);
+        }
+    }
+
+    // Make sure inserts have started
+    ThreadAPI_Sleep(1000);
+
+    CLDS_HASH_TABLE_ITEM** items;
+    uint64_t item_count;
+
+    // act
+    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, hazard_pointers_thread, &items, &item_count);
+
+    // Inserts continue to run a bit longer to make sure we are in a good state
+    ThreadAPI_Sleep(1000);
+
+    // Stop inserts
+    for (uint32_t i = 0; i < THREAD_COUNT; i++)
+    {
+        (void)InterlockedExchange(&thread_data[i].stop, 1);
+
+        int thread_result;
+        (void)ThreadAPI_Join(thread[i], &thread_result);
+        ASSERT_ARE_EQUAL(int, 0, thread_result);
+    }
+
+    // assert
+    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_SNAPSHOT_RESULT, CLDS_HASH_TABLE_SNAPSHOT_OK, result);
+    verify_all_items_present_ignore_extras(original_count, items, item_count);
+
+    // cleanup
+    cleanup_snapshot(items, item_count);
+    clds_hash_table_destroy(hash_table);
+    clds_hazard_pointers_destroy(hazard_pointers);
+}
+
+/* Tests_SRS_CLDS_HASH_TABLE_42_037: [ clds_hash_table_delete shall try the following until it acquires a write lock for the table: ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_038: [ clds_hash_table_delete shall increment the count of pending write operations. ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_039: [ If the counter to lock the table for writes is non-zero then: ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_040: [ clds_hash_table_delete shall decrement the count of pending write operations. ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_041: [ clds_hash_table_delete shall wait for the counter to lock the table for writes to reach 0 and repeat. ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_042: [ clds_hash_table_insert shall decrement the count of pending write operations. ]*/
+TEST_FUNCTION(clds_hash_table_snapshot_works_with_multiple_concurrent_deletes)
+{
+    // arrange
+    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    volatile int64_t sequence_number = 45;
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 1, hazard_pointers, &sequence_number, test_skipped_seq_no_cb, (void*)0x5556);
+
+    // Write additional items that will get deleted
+    uint32_t original_count = 10000;
+    uint32_t next_insert = original_count + 10000;
+    fill_hash_table_sequentially(hash_table, hazard_pointers_thread, next_insert);
+
+    // Start threads to insert additional items and delete
+    THREAD_DATA insert_thread_data[THREAD_COUNT];
+    THREAD_HANDLE insert_thread[THREAD_COUNT];
+
+    SHARED_KEY_INFO shared[THREAD_COUNT];
+
+    THREAD_DATA delete_thread_data[THREAD_COUNT];
+    THREAD_HANDLE delete_thread[THREAD_COUNT];
+
+    for (uint32_t i = 0; i < THREAD_COUNT; i++)
+    {
+        (void)InterlockedExchange(&shared[i].last_written_key, next_insert - 1);
+
+        initialize_thread_data(&insert_thread_data[i], &shared[i], hash_table, hazard_pointers, next_insert + i, THREAD_COUNT);
+
+        initialize_thread_data(&delete_thread_data[i], &shared[i], hash_table, hazard_pointers, next_insert + i, THREAD_COUNT);
+
+        if (ThreadAPI_Create(&insert_thread[i], continuous_insert_thread, &insert_thread_data[i]) != THREADAPI_OK)
+        {
+            ASSERT_FAIL("Error spawning insert test thread %" PRIu32, i);
+        }
+
+        if (ThreadAPI_Create(&delete_thread[i], continuous_delete_thread, &delete_thread_data[i]) != THREADAPI_OK)
+        {
+            ASSERT_FAIL("Error spawning delete test thread %" PRIu32, i);
+        }
+    }
+
+    // Make sure inserts and deletes have started
+    ThreadAPI_Sleep(1000);
+
+    CLDS_HASH_TABLE_ITEM** items;
+    uint64_t item_count;
+
+    // act
+    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, hazard_pointers_thread, &items, &item_count);
+
+    // Inserts and deletes continue to run a bit longer to make sure we are in a good state
+    ThreadAPI_Sleep(1000);
+
+    // Stop inserts
+    for (uint32_t i = 0; i < THREAD_COUNT; i++)
+    {
+        (void)InterlockedExchange(&delete_thread_data[i].stop, 1);
+        (void)InterlockedExchange(&insert_thread_data[i].stop, 1);
+
+        int thread_result;
+        (void)ThreadAPI_Join(delete_thread[i], &thread_result);
+        ASSERT_ARE_EQUAL(int, 0, thread_result);
+
+        (void)ThreadAPI_Join(insert_thread[i], &thread_result);
+        ASSERT_ARE_EQUAL(int, 0, thread_result);
+    }
+
+    // assert
+    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_SNAPSHOT_RESULT, CLDS_HASH_TABLE_SNAPSHOT_OK, result);
+    verify_all_items_present_ignore_extras(original_count, items, item_count);
+
+    // cleanup
+    cleanup_snapshot(items, item_count);
+    clds_hash_table_destroy(hash_table);
+    clds_hazard_pointers_destroy(hazard_pointers);
+}
+
+/* Tests_SRS_CLDS_HASH_TABLE_42_043: [ clds_hash_table_delete_key_value shall try the following until it acquires a write lock for the table: ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_044: [ clds_hash_table_delete_key_value shall increment the count of pending write operations. ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_045: [ If the counter to lock the table for writes is non-zero then: ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_046: [ clds_hash_table_delete_key_value shall decrement the count of pending write operations. ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_047: [ clds_hash_table_delete_key_value shall wait for the counter to lock the table for writes to reach 0 and repeat. ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_048: [ clds_hash_table_delete_key_value shall decrement the count of pending write operations. ]*/
+TEST_FUNCTION(clds_hash_table_snapshot_works_with_multiple_concurrent_delete_key_value)
+{
+    // arrange
+    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    volatile int64_t sequence_number = 45;
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 1, hazard_pointers, &sequence_number, test_skipped_seq_no_cb, (void*)0x5556);
+
+    // Write additional items that will get deleted
+    uint32_t original_count = 10000;
+    uint32_t next_insert = original_count + 10000;
+    fill_hash_table_sequentially(hash_table, hazard_pointers_thread, next_insert);
+
+    // Start threads to insert additional items and delete
+    THREAD_DATA insert_thread_data[THREAD_COUNT];
+    THREAD_HANDLE insert_thread[THREAD_COUNT];
+
+    SHARED_KEY_INFO shared[THREAD_COUNT];
+
+    THREAD_DATA delete_thread_data[THREAD_COUNT];
+    THREAD_HANDLE delete_thread[THREAD_COUNT];
+
+    for (uint32_t i = 0; i < THREAD_COUNT; i++)
+    {
+        (void)InterlockedExchange(&shared[i].last_written_key, next_insert - 1);
+
+        initialize_thread_data(&insert_thread_data[i], &shared[i], hash_table, hazard_pointers, next_insert + i, THREAD_COUNT);
+
+        initialize_thread_data(&delete_thread_data[i], &shared[i], hash_table, hazard_pointers, next_insert + i, THREAD_COUNT);
+
+        if (ThreadAPI_Create(&insert_thread[i], continuous_insert_thread, &insert_thread_data[i]) != THREADAPI_OK)
+        {
+            ASSERT_FAIL("Error spawning insert test thread %" PRIu32, i);
+        }
+
+        if (ThreadAPI_Create(&delete_thread[i], continuous_delete_key_value_thread, &delete_thread_data[i]) != THREADAPI_OK)
+        {
+            ASSERT_FAIL("Error spawning delete test thread %" PRIu32, i);
+        }
+    }
+
+    // Make sure inserts and deletes have started
+    ThreadAPI_Sleep(1000);
+
+    CLDS_HASH_TABLE_ITEM** items;
+    uint64_t item_count;
+
+    // act
+    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, hazard_pointers_thread, &items, &item_count);
+
+    // Inserts and deletes continue to run a bit longer to make sure we are in a good state
+    ThreadAPI_Sleep(1000);
+
+    // Stop inserts
+    for (uint32_t i = 0; i < THREAD_COUNT; i++)
+    {
+        (void)InterlockedExchange(&delete_thread_data[i].stop, 1);
+        (void)InterlockedExchange(&insert_thread_data[i].stop, 1);
+
+        int thread_result;
+        (void)ThreadAPI_Join(delete_thread[i], &thread_result);
+        ASSERT_ARE_EQUAL(int, 0, thread_result);
+
+        (void)ThreadAPI_Join(insert_thread[i], &thread_result);
+        ASSERT_ARE_EQUAL(int, 0, thread_result);
+    }
+
+    // assert
+    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_SNAPSHOT_RESULT, CLDS_HASH_TABLE_SNAPSHOT_OK, result);
+    verify_all_items_present_ignore_extras(original_count, items, item_count);
+
+    // cleanup
+    cleanup_snapshot(items, item_count);
+    clds_hash_table_destroy(hash_table);
+    clds_hazard_pointers_destroy(hazard_pointers);
+}
+
+/* Tests_SRS_CLDS_HASH_TABLE_42_049: [ clds_hash_table_remove shall try the following until it acquires a write lock for the table: ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_050: [ clds_hash_table_remove shall increment the count of pending write operations. ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_051: [ If the counter to lock the table for writes is non-zero then: ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_052: [ clds_hash_table_remove shall decrement the count of pending write operations. ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_053: [ clds_hash_table_remove shall wait for the counter to lock the table for writes to reach 0 and repeat. ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_054: [ clds_hash_table_remove shall decrement the count of pending write operations. ]*/
+TEST_FUNCTION(clds_hash_table_snapshot_works_with_multiple_concurrent_remove)
+{
+    // arrange
+    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    volatile int64_t sequence_number = 45;
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 1, hazard_pointers, &sequence_number, test_skipped_seq_no_cb, (void*)0x5556);
+
+    // Write additional items that will get deleted
+    uint32_t original_count = 10000;
+    uint32_t next_insert = original_count + 10000;
+    fill_hash_table_sequentially(hash_table, hazard_pointers_thread, next_insert);
+
+    // Start threads to insert additional items and delete
+    THREAD_DATA insert_thread_data[THREAD_COUNT];
+    THREAD_HANDLE insert_thread[THREAD_COUNT];
+
+    SHARED_KEY_INFO shared[THREAD_COUNT];
+
+    THREAD_DATA delete_thread_data[THREAD_COUNT];
+    THREAD_HANDLE delete_thread[THREAD_COUNT];
+
+    for (uint32_t i = 0; i < THREAD_COUNT; i++)
+    {
+        (void)InterlockedExchange(&shared[i].last_written_key, next_insert - 1);
+
+        initialize_thread_data(&insert_thread_data[i], &shared[i], hash_table, hazard_pointers, next_insert + i, THREAD_COUNT);
+
+        initialize_thread_data(&delete_thread_data[i], &shared[i], hash_table, hazard_pointers, next_insert + i, THREAD_COUNT);
+
+        if (ThreadAPI_Create(&insert_thread[i], continuous_insert_thread, &insert_thread_data[i]) != THREADAPI_OK)
+        {
+            ASSERT_FAIL("Error spawning insert test thread %" PRIu32, i);
+        }
+
+        if (ThreadAPI_Create(&delete_thread[i], continuous_remove_thread, &delete_thread_data[i]) != THREADAPI_OK)
+        {
+            ASSERT_FAIL("Error spawning delete test thread %" PRIu32, i);
+        }
+    }
+
+    // Make sure inserts and deletes have started
+    ThreadAPI_Sleep(1000);
+
+    CLDS_HASH_TABLE_ITEM** items;
+    uint64_t item_count;
+
+    // act
+    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, hazard_pointers_thread, &items, &item_count);
+
+    // Inserts and deletes continue to run a bit longer to make sure we are in a good state
+    ThreadAPI_Sleep(1000);
+
+    // Stop inserts
+    for (uint32_t i = 0; i < THREAD_COUNT; i++)
+    {
+        (void)InterlockedExchange(&delete_thread_data[i].stop, 1);
+        (void)InterlockedExchange(&insert_thread_data[i].stop, 1);
+
+        int thread_result;
+        (void)ThreadAPI_Join(delete_thread[i], &thread_result);
+        ASSERT_ARE_EQUAL(int, 0, thread_result);
+
+        (void)ThreadAPI_Join(insert_thread[i], &thread_result);
+        ASSERT_ARE_EQUAL(int, 0, thread_result);
+    }
+
+    // assert
+    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_SNAPSHOT_RESULT, CLDS_HASH_TABLE_SNAPSHOT_OK, result);
+    verify_all_items_present_ignore_extras(original_count, items, item_count);
+
+    // cleanup
+    cleanup_snapshot(items, item_count);
+    clds_hash_table_destroy(hash_table);
+    clds_hazard_pointers_destroy(hazard_pointers);
+}
+
+/* Tests_SRS_CLDS_HASH_TABLE_42_055: [ clds_hash_table_set_value shall try the following until it acquires a write lock for the table: ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_056: [ clds_hash_table_set_value shall increment the count of pending write operations. ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_057: [ If the counter to lock the table for writes is non-zero then: ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_058: [ clds_hash_table_set_value shall decrement the count of pending write operations. ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_059: [ clds_hash_table_set_value shall wait for the counter to lock the table for writes to reach 0 and repeat. ]*/
+/* Tests_SRS_CLDS_HASH_TABLE_42_060: [ clds_hash_table_set_value shall decrement the count of pending write operations. ]*/
+TEST_FUNCTION(clds_hash_table_snapshot_works_with_multiple_concurrent_set_value)
+{
+    // arrange
+    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    volatile int64_t sequence_number = 45;
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 1, hazard_pointers, &sequence_number, test_skipped_seq_no_ignore /*This is noisy with set_value*/, (void*)0x5556);
+
+    uint32_t original_count = 10000;
+    fill_hash_table_sequentially(hash_table, hazard_pointers_thread, original_count);
+
+    // Start threads to set value on th existing items
+    SHARED_KEY_INFO shared[THREAD_COUNT];
+
+    THREAD_DATA set_thread_data[THREAD_COUNT];
+    THREAD_HANDLE set_thread[THREAD_COUNT];
+
+    for (uint32_t i = 0; i < THREAD_COUNT; i++)
+    {
+        (void)InterlockedExchange(&shared[i].last_written_key, original_count - 1);
+
+        initialize_thread_data(&set_thread_data[i], &shared[i], hash_table, hazard_pointers, i, THREAD_COUNT);
+
+        if (ThreadAPI_Create(&set_thread[i], continuous_set_value_thread, &set_thread_data[i]) != THREADAPI_OK)
+        {
+            ASSERT_FAIL("Error spawning set value test thread %" PRIu32, i);
+        }
+    }
+
+    // Make sure set value has started
+    ThreadAPI_Sleep(1000);
+
+    CLDS_HASH_TABLE_ITEM** items;
+    uint64_t item_count;
+
+    // act
+    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, hazard_pointers_thread, &items, &item_count);
+
+    // Set value continues to run a bit longer to make sure we are in a good state
+    ThreadAPI_Sleep(1000);
+
+    // Stop set value
+    for (uint32_t i = 0; i < THREAD_COUNT; i++)
+    {
+        (void)InterlockedExchange(&set_thread_data[i].stop, 1);
+
+        int thread_result;
+        (void)ThreadAPI_Join(set_thread[i], &thread_result);
+        ASSERT_ARE_EQUAL(int, 0, thread_result);
+    }
+
+    // assert
+    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_SNAPSHOT_RESULT, CLDS_HASH_TABLE_SNAPSHOT_OK, result);
+    verify_all_items_present(original_count, items, item_count);
+
+    // cleanup
+    cleanup_snapshot(items, item_count);
+    clds_hash_table_destroy(hash_table);
+    clds_hazard_pointers_destroy(hazard_pointers);
+}
+
+TEST_FUNCTION(clds_hash_table_snapshot_works_with_multiple_concurrent_find)
+{
+    // arrange
+    CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
+    CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    volatile int64_t sequence_number = 45;
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 1, hazard_pointers, &sequence_number, test_skipped_seq_no_ignore /*This is noisy with set_value*/, (void*)0x5556);
+
+    uint32_t original_count = 10000;
+    fill_hash_table_sequentially(hash_table, hazard_pointers_thread, original_count);
+
+    // Start threads to set value on th existing items
+    SHARED_KEY_INFO shared[THREAD_COUNT];
+
+    THREAD_DATA find_thread_data[THREAD_COUNT];
+    THREAD_HANDLE find_thread[THREAD_COUNT];
+
+    for (uint32_t i = 0; i < THREAD_COUNT; i++)
+    {
+        (void)InterlockedExchange(&shared[i].last_written_key, original_count - 1);
+
+        initialize_thread_data(&find_thread_data[i], &shared[i], hash_table, hazard_pointers, i, THREAD_COUNT);
+
+        if (ThreadAPI_Create(&find_thread[i], continuous_set_value_thread, &find_thread_data[i]) != THREADAPI_OK)
+        {
+            ASSERT_FAIL("Error spawning find test thread %" PRIu32, i);
+        }
+    }
+
+    // Make sure set value has started
+    ThreadAPI_Sleep(1000);
+
+    CLDS_HASH_TABLE_ITEM** items;
+    uint64_t item_count;
+
+    // act
+    CLDS_HASH_TABLE_SNAPSHOT_RESULT result = clds_hash_table_snapshot(hash_table, hazard_pointers_thread, &items, &item_count);
+
+    // Find threads continue to run a bit longer to make sure we are in a good state
+    ThreadAPI_Sleep(1000);
+
+    // Stop find threads
+    for (uint32_t i = 0; i < THREAD_COUNT; i++)
+    {
+        (void)InterlockedExchange(&find_thread_data[i].stop, 1);
+
+        int thread_result;
+        (void)ThreadAPI_Join(find_thread[i], &thread_result);
+        ASSERT_ARE_EQUAL(int, 0, thread_result);
+    }
+
+    // assert
+    ASSERT_ARE_EQUAL(CLDS_HASH_TABLE_SNAPSHOT_RESULT, CLDS_HASH_TABLE_SNAPSHOT_OK, result);
+    verify_all_items_present(original_count, items, item_count);
+
+    // cleanup
+    cleanup_snapshot(items, item_count);
     clds_hash_table_destroy(hash_table);
     clds_hazard_pointers_destroy(hazard_pointers);
 }

--- a/tests/clds_hash_table_int/clds_hash_table_int.c
+++ b/tests/clds_hash_table_int/clds_hash_table_int.c
@@ -488,6 +488,7 @@ TEST_FUNCTION(clds_hash_table_create_succeeds)
 {
     // arrange
     CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
+    ASSERT_IS_NOT_NULL(hazard_pointers);
     CLDS_HASH_TABLE_HANDLE hash_table;
     volatile int64_t sequence_number = 45;
 
@@ -506,9 +507,12 @@ TEST_FUNCTION(clds_hash_table_insert_succeeds)
 {
     // arrange
     CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
+    ASSERT_IS_NOT_NULL(hazard_pointers);
     CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    ASSERT_IS_NOT_NULL(hazard_pointers_thread);
     volatile int64_t sequence_number = 45;
     CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 1, hazard_pointers, &sequence_number, test_skipped_seq_no_cb, (void*)0x5556);
+    ASSERT_IS_NOT_NULL(hash_table);
     CLDS_HASH_TABLE_INSERT_RESULT result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, NULL, NULL);
     int64_t insert_seq_no;
@@ -528,9 +532,12 @@ TEST_FUNCTION(clds_hash_table_delete_succeeds)
 {
     // arrange
     CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
+    ASSERT_IS_NOT_NULL(hazard_pointers);
     CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    ASSERT_IS_NOT_NULL(hazard_pointers_thread);
     volatile int64_t sequence_number = 45;
     CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 1, hazard_pointers, &sequence_number, test_skipped_seq_no_cb, (void*)0x5556);
+    ASSERT_IS_NOT_NULL(hash_table);
     CLDS_HASH_TABLE_INSERT_RESULT insert_result;
     CLDS_HASH_TABLE_DELETE_RESULT delete_result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, NULL, NULL);
@@ -555,9 +562,12 @@ TEST_FUNCTION(clds_hash_table_insert_in_higher_level_buckets_array_returns_alrea
 {
     // arrange
     CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
+    ASSERT_IS_NOT_NULL(hazard_pointers);
     CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    ASSERT_IS_NOT_NULL(hazard_pointers_thread);
     volatile int64_t sequence_number = 45;
     CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 1, hazard_pointers, &sequence_number, test_skipped_seq_no_cb, (void*)0x5556);
+    ASSERT_IS_NOT_NULL(hash_table);
     CLDS_HASH_TABLE_INSERT_RESULT insert_result;
     CLDS_HASH_TABLE_DELETE_RESULT delete_result;
     // 2 items to force expanding the hash table
@@ -592,9 +602,12 @@ TEST_FUNCTION(clds_hash_table_set_value_succeeds)
 {
     // arrange
     CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
+    ASSERT_IS_NOT_NULL(hazard_pointers);
     CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    ASSERT_IS_NOT_NULL(hazard_pointers_thread);
     volatile int64_t sequence_number = 45;
     CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 1, hazard_pointers, &sequence_number, test_skipped_seq_no_cb, (void*)0x5556);
+    ASSERT_IS_NOT_NULL(hash_table);
     CLDS_HASH_TABLE_SET_VALUE_RESULT set_value_result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, NULL, NULL);
     CLDS_HASH_TABLE_ITEM* old_item;
@@ -615,9 +628,12 @@ TEST_FUNCTION(clds_hash_table_set_value_when_the_key_exists_on_a_lower_level_fai
 {
     // arrange
     CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
+    ASSERT_IS_NOT_NULL(hazard_pointers);
     CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    ASSERT_IS_NOT_NULL(hazard_pointers_thread);
     volatile int64_t sequence_number = 45;
     CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 1, hazard_pointers, &sequence_number, test_skipped_seq_no_cb, (void*)0x5556);
+    ASSERT_IS_NOT_NULL(hash_table);
     CLDS_HASH_TABLE_INSERT_RESULT insert_result;
     CLDS_HASH_TABLE_SET_VALUE_RESULT set_value_result;
     CLDS_HASH_TABLE_DELETE_RESULT delete_result;
@@ -656,9 +672,12 @@ TEST_FUNCTION(clds_hash_table_delete_after_set_value_succeeds)
 {
     // arrange
     CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
+    ASSERT_IS_NOT_NULL(hazard_pointers);
     CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    ASSERT_IS_NOT_NULL(hazard_pointers_thread);
     volatile int64_t sequence_number = 45;
     CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 1, hazard_pointers, &sequence_number, test_skipped_seq_no_cb, (void*)0x5556);
+    ASSERT_IS_NOT_NULL(hash_table);
     CLDS_HASH_TABLE_SET_VALUE_RESULT set_value_result;
     CLDS_HASH_TABLE_DELETE_RESULT delete_result;
     CLDS_HASH_TABLE_ITEM* item = CLDS_HASH_TABLE_NODE_CREATE(TEST_ITEM, NULL, NULL);
@@ -684,9 +703,12 @@ TEST_FUNCTION(clds_hash_table_snapshot_works_with_10000_sequential_key_items)
 {
     // arrange
     CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
+    ASSERT_IS_NOT_NULL(hazard_pointers);
     CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    ASSERT_IS_NOT_NULL(hazard_pointers_thread);
     volatile int64_t sequence_number = 45;
     CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 1, hazard_pointers, &sequence_number, test_skipped_seq_no_cb, (void*)0x5556);
+    ASSERT_IS_NOT_NULL(hash_table);
 
     uint32_t original_count = 10000;
     fill_hash_table_sequentially(hash_table, hazard_pointers_thread, original_count);
@@ -720,9 +742,12 @@ TEST_FUNCTION(clds_hash_table_snapshot_works_with_concurrent_inserts)
 {
     // arrange
     CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
+    ASSERT_IS_NOT_NULL(hazard_pointers);
     CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    ASSERT_IS_NOT_NULL(hazard_pointers_thread);
     volatile int64_t sequence_number = 45;
     CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 1, hazard_pointers, &sequence_number, test_skipped_seq_no_cb, (void*)0x5556);
+    ASSERT_IS_NOT_NULL(hash_table);
 
     uint32_t original_count = 10000;
     fill_hash_table_sequentially(hash_table, hazard_pointers_thread, original_count);
@@ -773,9 +798,12 @@ TEST_FUNCTION(clds_hash_table_snapshot_works_with_multiple_concurrent_inserts)
 {
     // arrange
     CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
+    ASSERT_IS_NOT_NULL(hazard_pointers);
     CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    ASSERT_IS_NOT_NULL(hazard_pointers_thread);
     volatile int64_t sequence_number = 45;
     CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 1, hazard_pointers, &sequence_number, test_skipped_seq_no_cb, (void*)0x5556);
+    ASSERT_IS_NOT_NULL(hash_table);
 
     uint32_t original_count = 10000;
     fill_hash_table_sequentially(hash_table, hazard_pointers_thread, original_count);
@@ -839,9 +867,12 @@ TEST_FUNCTION(clds_hash_table_snapshot_works_with_multiple_concurrent_deletes)
 {
     // arrange
     CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
+    ASSERT_IS_NOT_NULL(hazard_pointers);
     CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    ASSERT_IS_NOT_NULL(hazard_pointers_thread);
     volatile int64_t sequence_number = 45;
     CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 1, hazard_pointers, &sequence_number, test_skipped_seq_no_cb, (void*)0x5556);
+    ASSERT_IS_NOT_NULL(hash_table);
 
     // Write additional items that will get deleted
     uint32_t original_count = 10000;
@@ -922,9 +953,12 @@ TEST_FUNCTION(clds_hash_table_snapshot_works_with_multiple_concurrent_delete_key
 {
     // arrange
     CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
+    ASSERT_IS_NOT_NULL(hazard_pointers);
     CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    ASSERT_IS_NOT_NULL(hazard_pointers_thread);
     volatile int64_t sequence_number = 45;
     CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 1, hazard_pointers, &sequence_number, test_skipped_seq_no_cb, (void*)0x5556);
+    ASSERT_IS_NOT_NULL(hash_table);
 
     // Write additional items that will get deleted
     uint32_t original_count = 10000;
@@ -1005,9 +1039,12 @@ TEST_FUNCTION(clds_hash_table_snapshot_works_with_multiple_concurrent_remove)
 {
     // arrange
     CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
+    ASSERT_IS_NOT_NULL(hazard_pointers);
     CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    ASSERT_IS_NOT_NULL(hazard_pointers_thread);
     volatile int64_t sequence_number = 45;
     CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 1, hazard_pointers, &sequence_number, test_skipped_seq_no_cb, (void*)0x5556);
+    ASSERT_IS_NOT_NULL(hash_table);
 
     // Write additional items that will get deleted
     uint32_t original_count = 10000;
@@ -1088,9 +1125,12 @@ TEST_FUNCTION(clds_hash_table_snapshot_works_with_multiple_concurrent_set_value)
 {
     // arrange
     CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
+    ASSERT_IS_NOT_NULL(hazard_pointers);
     CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    ASSERT_IS_NOT_NULL(hazard_pointers_thread);
     volatile int64_t sequence_number = 45;
     CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 1, hazard_pointers, &sequence_number, test_skipped_seq_no_ignore /*This is noisy with set_value*/, (void*)0x5556);
+    ASSERT_IS_NOT_NULL(hash_table);
 
     uint32_t original_count = 10000;
     fill_hash_table_sequentially(hash_table, hazard_pointers_thread, original_count);
@@ -1149,9 +1189,12 @@ TEST_FUNCTION(clds_hash_table_snapshot_works_with_multiple_concurrent_find)
 {
     // arrange
     CLDS_HAZARD_POINTERS_HANDLE hazard_pointers = clds_hazard_pointers_create();
+    ASSERT_IS_NOT_NULL(hazard_pointers);
     CLDS_HAZARD_POINTERS_THREAD_HANDLE hazard_pointers_thread = clds_hazard_pointers_register_thread(hazard_pointers);
+    ASSERT_IS_NOT_NULL(hazard_pointers_thread);
     volatile int64_t sequence_number = 45;
-    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 1, hazard_pointers, &sequence_number, test_skipped_seq_no_ignore /*This is noisy with set_value*/, (void*)0x5556);
+    CLDS_HASH_TABLE_HANDLE hash_table = clds_hash_table_create(test_compute_hash, test_key_compare, 1, hazard_pointers, &sequence_number, test_skipped_seq_no_cb, (void*)0x5556);
+    ASSERT_IS_NOT_NULL(hash_table);
 
     uint32_t original_count = 10000;
     fill_hash_table_sequentially(hash_table, hazard_pointers_thread, original_count);
@@ -1168,7 +1211,7 @@ TEST_FUNCTION(clds_hash_table_snapshot_works_with_multiple_concurrent_find)
 
         initialize_thread_data(&find_thread_data[i], &shared[i], hash_table, hazard_pointers, i, THREAD_COUNT);
 
-        if (ThreadAPI_Create(&find_thread[i], continuous_set_value_thread, &find_thread_data[i]) != THREADAPI_OK)
+        if (ThreadAPI_Create(&find_thread[i], continuous_find_thread, &find_thread_data[i]) != THREADAPI_OK)
         {
             ASSERT_FAIL("Error spawning find test thread %" PRIu32, i);
         }


### PR DESCRIPTION
This implements the `clds_hash_table_snapshot` function and adds tests around snapshots during concurrent operations.